### PR TITLE
Updated master/master.cfg to sign releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ master/state.sqlite
 master/twistd.log
 master/twistd.pid
 rust-bot-privkey.pem
-
+rust-bot-sign-secretkey.asc
+rust-bot-sign-passphrase

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1192,6 +1192,11 @@ def finish_dist(f, local_dist_dir, dist_subdirs, s3_addy, remote_dist_dir):
     f.addStep(MasterShellCommand(name="consolidate artifacts",
                                  command=["sh", "-c", WithProperties(consolidate_cmd)]))
 
+    # Generate signatures
+    sign_cmd = "for i in " + final_dist_dir + "/* ; do gpg --no-tty --yes --passphrase-fd 0 -a --detach-sign $i < ../rust-bot-sign-passphrase; done"
+    f.addStep(MasterShellCommand(name="signing",
+                                 command=["sh", "-c", WithProperties(sign_cmd)]))
+
     # Generate SHA 256 checksums for everything remaining
     sha256_cmd = "for i in " + final_dist_dir + "/* ; do sha256sum $i > $i.sha256; done"
     f.addStep(MasterShellCommand(name="checksumming",


### PR DESCRIPTION
Setup now requires GPG to be installed and in the PATH env variable, as well as the following files:

```
rust-bot-sign-secretkey.asc
rust-bot-sign-publickey.asc
rust-bot-sign-passphrase
```

Well, not necessarily the public key if you want to import subkeys yourself.

I put the passphrase in `rust-bot-sign-passphrase` because it seems as if Mozilla already does something similar for other software (see [passwords.py.template](https://github.com/mozilla/build-buildbot-configs/blob/master/mozilla/passwords.py.template). Except that this isn't Python.

**NOTE**: I couldn't get Rust's master.cfg to work locally, so I just made sure that signing worked for a test project of mine.  
**OTHER NOTE**: You'll also probably want to generate a subkey to use.
