### PR TITLE
passwords.py file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ master/gitpoller*
 master/http.log
 master/master.cfg.txt
 master/master.cfg.sample
+master/passwords.py
+master/passwords.pyc
 master/public_html
 master/runtests
 master/slave-list.txt

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1672,22 +1672,31 @@ c['status'] = []
 from buildbot.status import html
 from buildbot.status.web import authz, auth
 
-# we add one trivial user to prevent spambots from hitting the web UI
-# (yes, this has happened)
-users = [("rust", "rust")]
+# Import users, one that is able to build anything (any-build),
+# and another that is not allowed to build dists (no-dist).
+import passwords
+reload(passwords)
+
+def userAuth(username, builder_status):
+    if username == "any-build":
+        return True
+    if "dist" in builder_status.getName():
+        return False
+    return True
+
+def userAllAuth(username):
+    return username == "any-build"
 
 authz_cfg=authz.Authz(
-    auth=auth.BasicAuth(users),
-    # change any of these to True to enable; see the manual for more
-    # options
+    auth=auth.BasicAuth(passwords.users),
     gracefulShutdown = 'auth',
-    forceBuild = 'auth', # use this to test your slave once it is set up
-    forceAllBuilds = 'auth',
-    pingBuilder = 'auth',
-    stopBuild = 'auth',
-    stopAllBuilds = 'auth',
-    cancelPendingBuild = 'auth',
-    showUsersPage = 'auth',
+    forceBuild = userAuth,
+    forceAllBuilds = userAllAuth,
+    pingBuilder = userAuth,
+    stopBuild = userAuth,
+    stopAllBuilds = userAllAuth,
+    cancelPendingBuild = userAuth,
+    showUsersPage = 'auth'
 )
 
 #c['status'].append(

--- a/master/passwords.py.sample
+++ b/master/passwords.py.sample
@@ -1,0 +1,4 @@
+users = [
+    ('any-build', '123')
+    ('no-dist', '123')
+]


### PR DESCRIPTION
Changed to using a `passwords.py` file for storing credentials. This should take care of the whole "passwords being public" thing.

[See this issue.](https://github.com/rust-lang/rust/issues/20629)