### PR TITLE
Kill _all_ builders when a build fails

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1732,10 +1732,10 @@ class BSKiller(StatusReceiverMultiService):
         self.ctl = interfaces.IControl(self.master)
 
     def builderAdded(self, name, builder):
+        self.builders.append(builder)
         """choose to subscribe to the given builder"""
         if not self.buildermatch(name):
             return False
-        self.builders.append(builder)
         return self
 
     def buildFinished(self, buildername, build, result):


### PR DESCRIPTION
Currently builders that shouldn't cause the others to be killed aren't
killed themselves either when one of the gated builders fails. That
doesn't seem right.