### PR TITLE
bitrig make invocation

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -580,7 +580,7 @@ class MakeCommand(object):
     implements(IRenderable)
     def getRenderingFor(self, props):
         if "buildername" in props:
-            if "bsd" in props["buildername"]:
+            if "bsd" in props["buildername"] or "bitrig" in props["buildername"]:
                 return "gmake"
             if "win" in props["buildername"]:
                 # On windows dojob puts all children in a single taskgroup so they can be killed


### PR DESCRIPTION
bitrig (as bsd) have a BSD-make version. Use GNU-make (gmake) instead
for building rust.