### PR TITLE
Add initial MSVC bot configuration

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -126,12 +126,13 @@ auto_platforms_prod = [
 
     "linux-64-x-android-t",
 
-    "win-32-opt",
-    #"win-32-nopt-c",
-    "win-32-nopt-t",
-    "win-64-opt",
-    #"win-64-nopt-c",
-    "win-64-nopt-t",
+    "win-gnu-32-opt",
+    #"win-gnu-32-nopt-c",
+    "win-gnu-32-nopt-t",
+    "win-gnu-64-opt",
+    #"win-gnu-64-nopt-c",
+    "win-gnu-64-nopt-t",
+    "win-msvc-64-opt",
 
     # Tier 2 platforms, also modify nogate_builders
     "bsd-64-opt",
@@ -139,10 +140,10 @@ auto_platforms_prod = [
     "linux-musl-64-opt",
 ]
 
-try_platforms_prod = ["linux", "win-32", "win-64", "bsd", "mac"]
-snap_platforms_prod = ["linux", "win-32", "win-64", "bsd", "mac", "bitrig-64"]
-dist_platforms_prod = ["linux", "win-32", "win-64", "mac"]
-cargo_platforms_prod = ["linux-32", "linux-64", "mac-32", "mac-64", "win-32", "win-64"]
+try_platforms_prod = ["linux", "win-gnu-32", "win-gnu-64", "bsd", "mac"]
+snap_platforms_prod = ["linux", "win-gnu-32", "win-gnu-64", "bsd", "mac", "bitrig-64"]
+dist_platforms_prod = ["linux", "win-gnu-32", "win-gnu-64", "mac"]
+cargo_platforms_prod = ["linux-32", "linux-64", "mac-32", "mac-64", "win-gnu-32", "win-gnu-64"]
 
 # Development configuration
 auto_platforms_dev = [
@@ -153,20 +154,21 @@ auto_platforms_dev = [
 
     "linux-64-x-android-t",
 
-    "win-32-opt",
-    "win-32-nopt-t",
-    "win-64-opt",
-    "win-64-nopt-t",
+    "win-gnu-32-opt",
+    "win-gnu-32-nopt-t",
+    "win-gnu-64-opt",
+    "win-gnu-64-nopt-t",
+    "win-msvc-64-opt",
 
     "bsd-64-opt",
     "bitrig-64-opt",
     "linux-musl-64-opt",
 ]
 
-try_platforms_dev = ["linux", "win-32", "win-64", "bsd"]
-snap_platforms_dev = ["linux", "win-32", "win-64", "bsd", "bitrig-64"]
-dist_platforms_dev = ["linux", "win-32", "win-64"]
-cargo_platforms_dev = ["linux-32", "linux-64", "win-32", "win-64"]
+try_platforms_dev = ["linux", "win-gnu-32", "win-gnu-64", "bsd"]
+snap_platforms_dev = ["linux", "win-gnu-32", "win-gnu-64", "bsd", "bitrig-64"]
+dist_platforms_dev = ["linux", "win-gnu-32", "win-gnu-64"]
+cargo_platforms_dev = ["linux-32", "linux-64", "win-gnu-32", "win-gnu-64"]
 
 if env == "prod":
     auto_platforms = auto_platforms_prod
@@ -184,7 +186,12 @@ else:
 
 
 # auto-platforms that won't cause other's to fail (these don't gate bors)
-nogate_builders = ["auto-bsd-64-opt", "auto-bitrig-64-opt", "auto-linux-musl-64-opt"]
+nogate_builders = [
+    "auto-bsd-64-opt", 
+    "auto-bitrig-64-opt", 
+    "auto-linux-musl-64-opt",
+    "auto-win-msvc-64-opt",
+]
 
 
 ####### BUILDSLAVES
@@ -200,10 +207,14 @@ def all_platform_hosts(platform):
         return ["i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
     elif "bsd" in platform:
         return ["x86_64-unknown-freebsd"]
-    elif "win-32" in platform:
+    elif "win-gnu-32" in platform:
         return ["i686-pc-windows-gnu"]
-    elif "win-64" in platform:
+    elif "win-gnu-64" in platform:
         return ["x86_64-pc-windows-gnu"]
+    elif "win-msvc-32" in platform:
+        return ["i686-pc-windows-msvc"]
+    elif "win-msvc-64" in platform:
+        return ["x86_64-pc-windows-msvc"]
     elif "bitrig-64" in platform:
         return ["x86_64-unknown-bitrig"]
     else:
@@ -212,6 +223,10 @@ def all_platform_hosts(platform):
 def auto_platform_host(p):
     if "-all" in p:
         return "all"
+    # We are temporarily bootstrapping the MSVC build off a GNU build
+    elif "msvc" in p:
+        gnu = p.replace("msvc", "gnu")
+        return [auto_platform_triple(p), auto_platform_triple(gnu)]
     else:
         return [auto_platform_triple(p)]
 
@@ -238,16 +253,20 @@ def auto_platform_triple(p):
             return "x86_64-unknown-linux-gnu"
 
     if "win" in p:
+        env = "gnu" if "gnu" in p else "msvc"
         if "-32" in p:
-            return "i686-pc-windows-gnu"
+            return "i686-pc-windows-" + env
         else:
-            return "x86_64-pc-windows-gnu"
+            return "x86_64-pc-windows-" + env
 
     if "bsd" in p:
 	return "x86_64-unknown-freebsd"
 
     if "bitrig-64" in p:
         return "x86_64-unknown-bitrig"
+
+def auto_platform_build(p):
+    return auto_platform_triple(p.replace("msvc", "gnu"))
 
 
 ####### BUILDSLAVES
@@ -635,14 +654,19 @@ class CommandEnv(object):
             # This is required to trigger certain workarounds done
             # slave-side by buildbot. In particular omitting the PWD
             # variable with an unmangled pathname.
-            if "win-32" in props["buildername"]:
+            if "win-gnu-32" in props["buildername"]:
                 env["MACHTYPE"] = "i686-pc-msys"
                 env["MSYSTEM"] = "MINGW32"
                 env["PATH"] = win32toolchain + ";c:\\msys64\\usr\\bin;${PATH};c:\\msys64\\mingw32\\bin"
-            if "win-64" in props["buildername"]:
+            if "win-gnu-64" in props["buildername"]:
                 env["MACHTYPE"] = "x86_64-pc-msys"
                 env["MSYSTEM"] = "MINGW64"
                 env["PATH"] = win64toolchain + ";c:\\msys64\\usr\\bin;${PATH};c:\\msys64\\mingw64\\bin"
+
+            if "win-msvc-64" in props["buildername"]:
+                env["MACHTYPE"] = "x86_64-pc-win32"
+                env["MSYSTEM"] = "MINGW64"
+                env["PATH"] = win64toolchain + ";c:\\msys64\\mingw64\\bin;c:\\msys64\\usr\\bin;${PATH}"
 
 	if "valgrind" in props and props["valgrind"] == True:
             env["RUST_THREADS"]="1"
@@ -1436,6 +1460,8 @@ for p in auto_platforms:
     if "musl" in p:
         chk = "check-stage2-T-x86_64-unknown-linux-musl-H-x86_64-unknown-linux-gnu"
         musl = True
+    if "msvc" in p:
+        chk = False
     if not opt_compiler:
         chk = False
 
@@ -1461,7 +1487,7 @@ for p in auto_platforms:
                         "optimize-tests": opt_tests,
                         "android": android,
                         "musl": musl,
-                        "build": auto_platform_triple(p),
+                        "build": auto_platform_build(p),
                         "hosts": auto_platform_host(p),
                         "targets": auto_platform_target(p),
                         "check": chk},


### PR DESCRIPTION
* Rename all current windows builders to `win-gnu-XX`
* Currently bootstrap MSVC with a two-host build (other host is `windows-gnu`)
* Don't run tests for MSVC just yet
* Don't gate on MSVC just yet