### PR TITLE
Request spot instances

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -308,6 +308,8 @@ for line in open("slave-list.txt"):
 					build_wait_timeout=build_wait_timeout,
                                         # notify_on_missing=['admin@rust-lang.org'],
                                         max_builds=int(ext['max_builds']),
+                                        spot_instance=True,
+                                        max_spot_price=0.05,
                                         tags = { 'Name': env + "-slave-" + name })
         else:
             slave = BuildSlave(name, pw, max_builds=int(ext['max_builds']))


### PR DESCRIPTION
The max price is set to $0.05. In us-west-1, one region consistently has a price of around $0.032 for m3.xlarge.

I've never used EC2 instances but this appears to be all that is necessary to request spot instances.