### PR TITLE
unnecessary force of clang++ for bsd platforms

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -729,9 +729,6 @@ class CommandEnv(object):
             ld_path = "/home/rustbuild/gcc-4.7.4/lib64:" + ld_path
             env["LD_LIBRARY_PATH"] = ld_path
 
-        if "buildername" in props and "bsd" in props["buildername"]:
-            env["CXX"] = "clang++"
-
         if "cargo" in props:
             env["PLATFORM"] = props["platform"]
             env["BITS"] = props["bits"]


### PR DESCRIPTION
it is unnecessary to for clang++ on bsd platforms.  the config script should correctly detect CC and CXX on Bitrig, FreeBSD, DragonflyBSD, OpenBSD, and NetBSD.