### PR TITLE
Start gating on MSVC nightlies

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -207,10 +207,7 @@ nogate_builders = [
     "auto-dragonflybsd-64-opt",
     "auto-openbsd-64-opt"
 ]
-dist_nogate_platforms = [
-    "win-msvc-32", 
-    "win-msvc-64",
-]
+dist_nogate_platforms = []
 
 
 ####### BUILDSLAVES

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -148,7 +148,7 @@ snap_platforms_prod = ["linux", "win-gnu-32", "win-gnu-64", "mac", "bitrig-64",
                        "freebsd10_32-1", "freebsd10_64-1", "dragonflybsd-64-opt",
                        "openbsd-64-opt"]
 dist_platforms_prod = ["linux", "win-gnu-32", "win-gnu-64", "win-msvc-32", "win-msvc-64", "mac"]
-cargo_platforms_prod = ["linux-32", "linux-64", "mac-32", "mac-64", "win-gnu-32", 
+cargo_platforms_prod = ["linux-32", "linux-64", "mac-32", "mac-64", "win-gnu-32",
                         "win-gnu-64", "win-msvc-32", "win-msvc-64", "bitrig-64"]
 
 # Development configuration
@@ -180,7 +180,7 @@ snap_platforms_dev = ["linux", "win-gnu-32", "win-gnu-64", "bitrig-64",
                       "freebsd10_32-1", "freebsd10_64-1", "dragonflybsd-64-opt",
                       "openbsd-64-opt"]
 dist_platforms_dev = ["linux", "win-gnu-32", "win-gnu-64", "win-msvc-32", "win-msvc-64"]
-cargo_platforms_dev = ["linux-32", "linux-64", "win-gnu-32", "win-gnu-64", 
+cargo_platforms_dev = ["linux-32", "linux-64", "win-gnu-32", "win-gnu-64",
                        "bitrig-64", "win-msvc-32", "win-msvc-64"]
 
 if env == "prod":
@@ -200,7 +200,7 @@ else:
 
 # auto-platforms that won't cause other's to fail (these don't gate bors)
 nogate_builders = [
-    "auto-bitrig-64-opt", 
+    "auto-bitrig-64-opt",
     "auto-linux-musl-64-opt",
     "auto-freebsd10_32-1",
     "auto-freebsd10_64-1",


### PR DESCRIPTION
These have propagated to stable/beta/nightly so we should start gating to ensure that we always wait for them to finish. An example is that today there's no actual 64-bit MSVC nightly, but it was actually built and just happened to be packaged a little later than the rest. This should ensure that we wait for them all to get uploaded.