### PR TITLE
We actually need buildbot.tac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ master/auto*
 master/dist*
 master/try*
 master/snap3*
-master/buildbot.tac
 master/gitpoller*
 master/http.log
 master/master.cfg.txt

--- a/master/buildbot.tac
+++ b/master/buildbot.tac
@@ -1,0 +1,33 @@
+import os
+
+from twisted.application import service
+from buildbot.master import BuildMaster
+
+basedir = '/home/rustbuild/rust-buildbot/master'
+rotateLength = '10000000'
+maxRotatedFiles = '10'
+configfile = 'master.cfg'
+
+# Default umask for server
+umask = None
+
+# if this is a relocatable tac file, get the directory containing the TAC
+if basedir == '.':
+    import os.path
+    basedir = os.path.abspath(os.path.dirname(__file__))
+
+# note: this line is matched against to check that this is a buildmaster
+# directory; do not edit it.
+application = service.Application('buildmaster')
+from twisted.python.logfile import LogFile
+from twisted.python.log import ILogObserver, FileLogObserver
+logfile = LogFile.fromFullPath(os.path.join(basedir, "twistd.log"),
+rotateLength=rotateLength,
+                                maxRotatedFiles=maxRotatedFiles)
+application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
+
+m = BuildMaster(basedir, configfile, umask)
+m.setServiceParent(application)
+m.log_rotation.rotateLength = rotateLength
+m.log_rotation.maxRotatedFiles = maxRotatedFiles
+


### PR DESCRIPTION
Buildbot won't start without it. The docs [1] say to run `buildbot
create-master -r <directory>` to generate the file, but that command actually
results in Buildbot going "hey, I'm installed already, let's upgrade instead"
and not creating the file.

[1] http://docs.buildbot.net/0.8.0/full.html#Creating-a-buildmaster