### PR TITLE
make Docker install valgrind

### DIFF
--- a/slaves/linux/Dockerfile
+++ b/slaves/linux/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update
 RUN apt-get install -y \
         curl make cmake xz-utils git \
         python-dev python-pip stunnel \
-        g++-multilib libssl-dev libssl-dev:i386 gdb
+        g++-multilib libssl-dev libssl-dev:i386 gdb \
+        valgrind
 
 # Install buildbot and prep it to run
 RUN pip install buildbot-slave


### PR DESCRIPTION
Checked for a `valgrind --version` on prod-slave-linux-3 but it's not
installed there.

fixes https://github.com/rust-lang/rust-buildbot/issues/45