### PR TITLE
Verify checksums after downloading source.

### DIFF
--- a/slaves/dist/Dockerfile
+++ b/slaves/dist/Dockerfile
@@ -29,14 +29,14 @@ RUN chown rustbuild:rustbuild /home/rustbuild
 # After we're done building we erase the binutils/gcc installs from CentOS to
 # ensure that we always use the ones that we just built.
 COPY dist/build_gcc.sh /build/
-RUN sh build_gcc.sh && rm -rf /build
+RUN /bin/bash build_gcc.sh && rm -rf /build
 
 # We need a build of openssl which supports SNI to download artifacts from
 # static.rust-lang.org. This'll be used to link into libcurl below (and used
 # later as well), so build a copy of OpenSSL with dynamic libraries into our
 # generic root.
 COPY dist/build_openssl.sh /build/
-RUN sh build_openssl.sh && rm -rf /build
+RUN /bin/bash build_openssl.sh && rm -rf /build
 
 # The `curl` binary on CentOS doesn't support SNI which is needed for fetching
 # some https urls we have, so install a new version of libcurl + curl which is
@@ -45,39 +45,39 @@ RUN sh build_openssl.sh && rm -rf /build
 # Note that we also disable a bunch of optional features of curl that we don't
 # really need.
 COPY dist/build_curl.sh /build/
-RUN sh build_curl.sh
+RUN /bin/bash build_curl.sh
 
 # binutils < 2.22 has a bug where the 32-bit executables it generates
 # immediately segfault in Rust, so we need to install our own binutils.
 #
 # See https://github.com/rust-lang/rust/issues/20440 for more info
 COPY dist/build_binutils.sh /build/
-RUN sh build_binutils.sh && rm -rf /build
+RUN /bin/bash build_binutils.sh && rm -rf /build
 
 # libssh2 (a dependency of Cargo) requires cmake 2.8.11 or higher but CentOS
 # only has 2.6.4, so build our own
 COPY dist/build_cmake.sh /build/
-RUN sh build_cmake.sh && rm -rf /build
+RUN /bin/bash build_cmake.sh && rm -rf /build
 
 # tar on CentOS is too old as it doesn't understand the --exclude-vcs option
 # that the Rust build system passes it, so install a new version.
 COPY dist/build_tar.sh /build/
-RUN sh build_tar.sh && rm -rf /build
+RUN /bin/bash build_tar.sh && rm -rf /build
 
 # CentOS 5.5 has Python 2.4 by default, but LLVM needs 2.7+
 COPY dist/build_python.sh /build/
-RUN sh build_python.sh && rm -rf /build
+RUN /bin/bash build_python.sh && rm -rf /build
 
 # The Rust test suite requires a relatively new version of gdb, much newer than
 # CentOS has to offer by default, and we want it to use the newly installed
 # python so it's ordered here.
 COPY dist/build_gdb.sh /build/
-RUN sh build_gdb.sh && rm -rf /build
+RUN /bin/bash build_gdb.sh && rm -rf /build
 
 # Apparently CentOS 5.5 desn't have `git` in yum, but we're gonna need it for
 # cloning, so download and build it here.
 COPY dist/build_git.sh /build/
-RUN sh build_git.sh && rm -rf /build
+RUN /bin/bash build_git.sh && rm -rf /build
 
 # Install buildbot and prep it to run
 RUN curl https://bootstrap.pypa.io/ez_setup.py | python

--- a/slaves/dist/build_binutils.sh
+++ b/slaves/dist/build_binutils.sh
@@ -1,11 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
-curl https://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2 | tar xjf -
+VERSION=2.25.1
+SHA256=b5b14added7d78a8d1ca70b5cb75fef57ce2197264f4f5835326b0df22ac9f22
+
+curl https://ftp.gnu.org/gnu/binutils/binutils-$VERSION.tar.bz2 | \
+  tee >(sha256sum > binutils-$VERSION.tar.bz2.sha256)           | tar xjf -
+test $SHA256 = $(cut -d ' ' -f 1 binutils-$VERSION.tar.bz2.sha256) || exit 1
+
 mkdir binutils-build
 cd binutils-build
-../binutils-2.25.1/configure --prefix=/rustroot
+../binutils-$VERSION/configure --prefix=/rustroot
 make -j10
 make install
 yum erase -y binutils

--- a/slaves/dist/build_cmake.sh
+++ b/slaves/dist/build_cmake.sh
@@ -1,10 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
-curl https://cmake.org/files/v3.3/cmake-3.3.2.tar.gz | tar xzf -
+VERSION=3.3.2
+SHA256=e75a178d6ebf182b048ebfe6e0657c49f0dc109779170bad7ffcb17463f2fc22
+
+curl https://cmake.org/files/v${VERSION%\.*}/cmake-$VERSION.tar.gz | \
+  tee >(sha256sum > cmake-$VERSION.tar.gz.sha256)                  | tar xzf -
+test $SHA256 = $(cut -d ' ' -f 1 cmake-$VERSION.tar.gz.sha256) || exit 1
+
 mkdir cmake-build
 cd cmake-build
-../cmake-3.3.2/configure --prefix=/rustroot
+../cmake-$VERSION/configure --prefix=/rustroot
 make -j10
 make install

--- a/slaves/dist/build_curl.sh
+++ b/slaves/dist/build_curl.sh
@@ -1,11 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
-curl http://curl.haxx.se/download/curl-7.44.0.tar.bz2 | tar xjf -
+VERSION=7.44.0
+SHA256=1e2541bae6582bb697c0fbae49e1d3e6fad5d05d5aa80dbd6f072e0a44341814
+
+curl http://curl.haxx.se/download/curl-$VERSION.tar.bz2 | \
+  tee >(sha256sum > curl-$VERSION.tar.bz2.sha256)       | tar xjf -
+test $SHA256 = $(cut -d ' ' -f 1 curl-$VERSION.tar.bz2.sha256) || exit 1
+
 mkdir curl-build
 cd curl-build
-../curl-7.44.0/configure --prefix=/rustroot --with-ssl=/rustroot \
+../curl-$VERSION/configure --prefix=/rustroot --with-ssl=/rustroot \
       --disable-sspi --disable-gopher --disable-smtp --disable-smb \
       --disable-imap --disable-pop3 --disable-tftp --disable-telnet \
       --disable-manual --disable-dict --disable-rtsp --disable-ldaps \

--- a/slaves/dist/build_gcc.sh
+++ b/slaves/dist/build_gcc.sh
@@ -1,14 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
+VERSION=4.7.4
+SHA256=92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282
+
 yum install -y wget
-curl https://ftp.gnu.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2 | tar xjf -
-cd gcc-4.7.4
+curl https://ftp.gnu.org/gnu/gcc/gcc-$VERSION/gcc-$VERSION.tar.bz2 | \
+  tee >(sha256sum > gcc-$VERSION.tar.bz2.sha256) | tar xjf -
+test $SHA256 = $(cut -d ' ' -f 1 gcc-$VERSION.tar.bz2.sha256) || exit 1
+
+cd gcc-$VERSION
 ./contrib/download_prerequisites
-mkdir ../gcc-4.7.4-build
-cd ../gcc-4.7.4-build
-../gcc-4.7.4/configure --prefix=/rustroot --enable-languages=c,c++
+mkdir ../gcc-$VERSION-build
+cd ../gcc-$VERSION-build
+../gcc-$VERSION/configure --prefix=/rustroot --enable-languages=c,c++
 make -j10
 make install
 ln -nsf gcc /rustroot/bin/cc

--- a/slaves/dist/build_gdb.sh
+++ b/slaves/dist/build_gdb.sh
@@ -1,12 +1,18 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
+VERSION=7.9.1
+SHA256=4994ad986726ac4128a6f1bd8020cd672e9a92aa76b80736563ef992992764ef
+
 yum install -y texinfo ncurses-devel
-curl https://ftp.gnu.org/gnu/gdb/gdb-7.9.1.tar.gz | tar xzf -
+curl https://ftp.gnu.org/gnu/gdb/gdb-$VERSION.tar.gz | \
+  tee >(sha256sum > gdb-$VERSION.tar.gz.sha256)      | tar xzf -
+test $SHA256 = $(cut -d ' ' -f 1 gdb-$VERSION.tar.gz.sha256) || exit 1
+
 mkdir gdb-build
 cd gdb-build
-../gdb-7.9.1/configure --prefix=/rustroot
+../gdb-$VERSION/configure --prefix=/rustroot
 make -j10
 make install
 yum erase -y texinfo ncurses-devel

--- a/slaves/dist/build_git.sh
+++ b/slaves/dist/build_git.sh
@@ -1,10 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
+VERSION=2.5.3
+SHA256=ebf3fb0f3f286d5f193efeca88e34c40a3cb53c985a1f53de0dbf08c3e5af979
+
 yum install -y gettext autoconf
-curl https://www.kernel.org/pub/software/scm/git/git-2.5.3.tar.gz | tar xzf -
-cd git-2.5.3
+curl https://www.kernel.org/pub/software/scm/git/git-$VERSION.tar.gz | \
+  tee >(sha256sum > git-$VERSION.tar.gz.sha256) | tar xzf -
+test $SHA256 = $(cut -d ' ' -f 1 git-$VERSION.tar.gz.sha256) || exit 1
+
+cd git-$VERSION
 make configure
 ./configure --prefix=/rustroot
 make -j10

--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -1,11 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
 VERSION=1.0.2d
+SHA256=671c36487785628a703374c652ad2cebea45fa920ae5681515df25d9f2c9a8c8
 
 yum install -y setarch
-curl http://openssl.org/source/openssl-$VERSION.tar.gz | tar xzf -
+curl http://openssl.org/source/openssl-$VERSION.tar.gz | \
+  tee >(sha256sum > openssl-$VERSION.tar.gz.sha256)    | tar xzf -
+test $SHA256 = $(cut -d ' ' -f 1 openssl-$VERSION.tar.gz.sha256) || exit 1
+
 cp -r openssl-$VERSION openssl-static-64
 cp -r openssl-$VERSION openssl-static-32
 cd openssl-$VERSION

--- a/slaves/dist/build_pkgconfig.sh
+++ b/slaves/dist/build_pkgconfig.sh
@@ -1,10 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
-curl http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.tar.gz | tar xzf -
+VERSION=0.29
+SHA256=c8507705d2a10c67f385d66ca2aae31e81770cc0734b4191eb8c489e864a006b
+
+curl http://pkgconfig.freedesktop.org/releases/pkg-config-$VERSION.tar.gz | \
+  tee >(sha256sum > pkg-config-$VERSION.tar.gz.sha256) | tar xzf -
+test $SHA256 = $(cut -d ' ' -f 1 pkg-config-$VERSION.tar.gz.sha256) || exit 1
+
 mkdir pkg-config-build
 cd pkg-config-build
-../pkg-config-0.29/configure --prefix=/rustroot --with-internal-glib
+../pkg-config-$VERSION/configure --prefix=/rustroot --with-internal-glib
 make -j10
 make install

--- a/slaves/dist/build_python.sh
+++ b/slaves/dist/build_python.sh
@@ -1,16 +1,22 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
+VERSION=2.7.10
+SHA256=eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a
+
 yum install -y bzip2-devel
-curl https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz | tar xzf -
+curl https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz | \
+  tee >(sha256sum > Python-$VERSION.tgz.sha256) | tar xzf -
+test $SHA256 = $(cut -d ' ' -f 1 Python-$VERSION.tgz.sha256) || exit 1
+
 mkdir python-build
 cd python-build
 
 # Gotta do some hackery to tell python about our custom OpenSSL build, but other
 # than that fairly normal.
 CFLAGS='-I /rustroot/include' LDFLAGS='-L /rustroot/lib -L /rustroot/lib64' \
-    ../Python-2.7.10/configure --prefix=/rustroot
+    ../Python-$VERSION/configure --prefix=/rustroot
 make -j10
 make install
 yum erase -y bzip2-devel

--- a/slaves/dist/build_tar.sh
+++ b/slaves/dist/build_tar.sh
@@ -1,8 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
-curl https://ftp.gnu.org/gnu/tar/tar-1.28.tar.bz2 | tar xjf -
+VERSION=1.28
+SHA256=60e4bfe0602fef34cd908d91cf638e17eeb09394d7b98c2487217dc4d3147562
+
+curl https://ftp.gnu.org/gnu/tar/tar-$VERSION.tar.bz2 | \
+  tee >(sha256sum > tar-$VERSION.tar.bz2.sha256)      | tar xjf -
+test $SHA256 = $(cut -d ' ' -f 1 tar-$VERSION.tar.bz2.sha256) || exit 1
+
 mkdir tar-build
 cd tar-build
 
@@ -16,7 +22,7 @@ cd tar-build
 # requires us to do that if we're running as root (which we are). Trust me
 # though, "I got this".
 CFLAGS=-D_FORTIFY_SOURCE=0 FORCE_UNSAFE_CONFIGURE=1 \
-    ../tar-1.28/configure --prefix=/rustroot
+    ../tar-$VERSION/configure --prefix=/rustroot
 
 make -j10
 make install


### PR DESCRIPTION
Keep a 256 bit SHA-2 checksum for the source packages we build
in each build script, and verify it after download. This protects
against corrupt archives and gives us another way to track how
the build environment is created.

Using the `tee >(sha256sum)` trick to pass the curl output to a
subshell as well as tar requires bash. To do this in portable
shell we need to write the tarball to disk, increasing temporary
image footprint.