### PR TITLE
Update to openssl 1.0.2e.

### DIFF
--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=1.0.2d
-SHA256=671c36487785628a703374c652ad2cebea45fa920ae5681515df25d9f2c9a8c8
+VERSION=1.0.2e
+SHA256=e23ccafdb75cfcde782da0151731aa2185195ac745eea3846133f2e05c0e0bff
 
 yum install -y setarch
 curl http://openssl.org/source/openssl-$VERSION.tar.gz | \


### PR DESCRIPTION
New upstream release today. Issues seem to be a weakness with DHE and a couple of crash bugs. https://openssl.org/news/secadv/20151203.txt

r? @edunham 