### PR TITLE
Python 2.7.11

### DIFF
--- a/slaves/dist/Dockerfile
+++ b/slaves/dist/Dockerfile
@@ -80,8 +80,8 @@ COPY dist/build_git.sh /build/
 RUN /bin/bash build_git.sh && rm -rf /build
 
 # Install buildbot and prep it to run
-RUN curl https://bootstrap.pypa.io/ez_setup.py | python
-RUN easy_install buildbot-slave
+RUN curl https://bootstrap.pypa.io/get-pip.py | python
+RUN pip install buildbot-slave
 
 # Clean up after ourselves, make sure that `cc` is a thing, and then make the
 # default working directory a "home-ish" directory

--- a/slaves/dist/build_python.sh
+++ b/slaves/dist/build_python.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=2.7.10
-SHA256=eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a
+VERSION=2.7.11
+SHA256=82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6
 
 yum install -y bzip2-devel
 curl https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz | \


### PR DESCRIPTION
Bump python, but more importantly, work around cert validation breakage by switching to pip.
