### PR TITLE
Fix cargo call to finish_dist

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -159,6 +159,7 @@ cargo_platforms = ["linux-32", "linux-64", "mac-32", "mac-64",
                    "win-gnu-32", "win-gnu-64",
                    "win-msvc-32", "win-msvc-64",
                    "bitrig-64"]
+cargo_dist_platforms = [p for p in cargo_platforms if "linux" in p or "mac" in p or "win" in p]
 
 def works_in_dev(platform):
     return 'mac' not in platform and \
@@ -1063,18 +1064,15 @@ def cargo_nightly_buildfactory(platform, host):
                                  command=["sh", "-c", WithProperties(commit_id_cmd)]))
 
     all_cargo_hosts = []
-    for p in dist_platforms:
+    for p in cargo_dist_platforms:
         for h in all_platform_hosts(p):
             all_cargo_hosts += [h]
-    nogate_cargo_hosts = []
-    for p in dist_nogate_platforms:
-        for h in all_platform_hosts(p):
-            nogate_cargo_hosts += [h]
+    all_cargo_hosts = list(set(all_cargo_hosts))
 
     f.addStep(DistSync(name="checking for synced cargo dist builds",
                        stagingDir=local_dist_dir,
                        platforms=all_cargo_hosts,
-                       nogate_platforms=nogate_cargo_hosts,
+                       nogate_platforms=[],
                        haltOnFailure=True,
                        flunkOnFailure=False))
 


### PR DESCRIPTION
Use the `cargo_platforms` as the start for learning all hosts that Cargo has
nightlies for (e.g. if you have an auto platform then you have a dist platform
assumed). Also uniq-ify this set as there are repeats (e.g. the set of "all
hosts" for the "linux-32" builder is the same as the "linux-64" builder).
Finally, also don't set any nogate builders as we're gating on everything for
Cargo right now.