### PR TITLE
Set up iOS slaves for nightly builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -112,6 +112,7 @@ auto_platforms = [
     "mac-64-nopt-t",
     #"mac-64-opt-vg",
     #"mac-all-opt",
+    "mac-ios-opt",
 
     "linux-32-opt",
     #"linux-32-nopt-c",
@@ -150,6 +151,7 @@ snap_platforms = ["linux", "win-gnu-32", "win-gnu-64", "mac", "bitrig-64",
                   "freebsd10_32-1", "freebsd10_64-1", "dragonflybsd-64-opt",
                   "openbsd-64-opt"]
 dist_platforms = ["linux", "mac", "arm-android", "musl-linux", "cross-linux",
+                  "mac-ios",
                   "win-gnu-32", "win-gnu-64",
                   "win-msvc-32", "win-msvc-64"]
 packaging_platforms = ["linux", "mac",
@@ -162,8 +164,7 @@ cargo_platforms = ["linux-32", "linux-64", "mac-32", "mac-64",
 cargo_dist_platforms = [p for p in cargo_platforms if "linux" in p or "mac" in p or "win" in p]
 
 def works_in_dev(platform):
-    return 'mac' not in platform and \
-          'bsd' not in platform and \
+    return 'bsd' not in platform and \
           'bitrig' not in platform
 
 if env != "prod":
@@ -185,6 +186,7 @@ nogate_builders = [
 ]
 dist_nogate_platforms = [
     "cross-linux",
+    "mac-ios",
 ]
 
 
@@ -537,7 +539,6 @@ c['schedulers'] = [
 try_sched,
 auto_sched,
 snap_sched,
-nightly_dist_rustc_trigger_sched,
 nightly_dist_rustc_sched,
 nightly_dist_packaging_sched,
 beta_dist_rustc_sched,
@@ -545,13 +546,16 @@ beta_dist_packaging_sched,
 stable_dist_rustc_sched,
 stable_dist_packaging_sched,
 cargo_sched,
-nightly_dist_cargo_trigger_sched,
 nightly_dist_cargo_sched,
 force_sched,
 master_force_sched,
 beta_force_sched,
 stable_force_sched
 ]
+
+if env == 'prod':
+    c['schedulers'].append(nightly_dist_rustc_trigger_sched)
+    c['schedulers'].append(nightly_dist_cargo_trigger_sched)
 
 ####### BUILDERS
 
@@ -1143,7 +1147,7 @@ def distsnap_buildfactory(platform, channel_label):
         command.append("check-stage2-T-x86_64-unknown-linux-musl-" + \
                        "H-x86_64-unknown-linux-gnu")
         command.append('dist')
-    elif 'cross-linux' in platform:
+    elif 'cross-linux' in platform or 'ios' in platform:
         command.append('dist')
     else:
         command.append('distcheck')
@@ -1521,6 +1525,13 @@ for p in auto_platforms:
         targets.append('mips-unknown-linux-gnu')
         targets.append('mipsel-unknown-linux-gnu')
         targets.append('aarch64-unknown-linux-gnu')
+    if "ios" in p:
+        chk = False
+        targets.append('aarch64-apple-ios')
+        targets.append('armv7-apple-ios')
+        targets.append('armv7s-apple-ios')
+        targets.append('i386-apple-ios')
+        targets.append('x86_64-apple-ios')
     if "msvc-32" in p:
         chk = False
     if not opt_compiler:
@@ -1594,6 +1605,13 @@ for p in dist_platforms:
         targets.append('mips-unknown-linux-gnu')
         targets.append('mipsel-unknown-linux-gnu')
         targets.append('aarch64-unknown-linux-gnu')
+    if "ios" in p:
+        hosts = ""
+        targets.append('aarch64-apple-ios')
+        targets.append('armv7-apple-ios')
+        targets.append('armv7s-apple-ios')
+        targets.append('i386-apple-ios')
+        targets.append('x86_64-apple-ios')
 
     for channel in ['nightly', 'beta', 'stable']:
         branch = 'master' if channel == 'nightly' else channel


### PR DESCRIPTION
Few changes here:

* There are new auto builders for the iOS builds
* Mac slaves are enabled in dev
* Nightly triggers are disabled in all but prod 
* Dist builders are set up for iOS (building standard libraries)