### PR TITLE
fix curl download

### DIFF
--- a/slaves/dist/build_curl.sh
+++ b/slaves/dist/build_curl.sh
@@ -5,7 +5,7 @@ set -ex
 VERSION=7.44.0
 SHA256=1e2541bae6582bb697c0fbae49e1d3e6fad5d05d5aa80dbd6f072e0a44341814
 
-curl http://curl.mirror.anstey.ca/curl-$VERSION.tar.bz2 | \
+curl http://cool.haxx.se/download/curl-$VERSION.tar.bz2 | \
   tee >(sha256sum > curl-$VERSION.tar.bz2.sha256)       | tar xjf -
 test $SHA256 = $(cut -d ' ' -f 1 curl-$VERSION.tar.bz2.sha256) || exit 1
 

--- a/slaves/dist/build_curl.sh
+++ b/slaves/dist/build_curl.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=7.44.0
-SHA256=1e2541bae6582bb697c0fbae49e1d3e6fad5d05d5aa80dbd6f072e0a44341814
+VERSION=7.47.1
+SHA256=ddc643ab9382e24bbe4747d43df189a0a6ce38fcb33df041b9cb0b3cd47ae98f
 
 curl http://cool.haxx.se/download/curl-$VERSION.tar.bz2 | \
   tee >(sha256sum > curl-$VERSION.tar.bz2.sha256)       | tar xjf -

--- a/slaves/dist/build_curl.sh
+++ b/slaves/dist/build_curl.sh
@@ -5,7 +5,7 @@ set -ex
 VERSION=7.44.0
 SHA256=1e2541bae6582bb697c0fbae49e1d3e6fad5d05d5aa80dbd6f072e0a44341814
 
-curl http://curl.haxx.se/download/curl-$VERSION.tar.bz2 | \
+curl http://curl.mirror.anstey.ca/curl-$VERSION.tar.bz2 | \
   tee >(sha256sum > curl-$VERSION.tar.bz2.sha256)       | tar xjf -
 test $SHA256 = $(cut -d ' ' -f 1 curl-$VERSION.tar.bz2.sha256) || exit 1
 


### PR DESCRIPTION
Build script was bit-rotted by haxx.se adding an http->https redirect, which the centos 5 curl is too old to follow. @bagder was kind enough to add an http-only alternative url.

Update to the latest version while we're here.