### PR TITLE
Make the system cert.pem available to python.

### DIFF
--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -32,3 +32,6 @@ make install
 ln -nsf /rustroot/cargo32 /home/rustbuild/root32
 ln -nsf /rustroot/cargo64 /home/rustbuild/root64
 yum erase -y setarch
+
+# Make the system cert collection available to the new install.
+ln -nsf /etc/pki/tls/cert.pem /rustroot/ssl/


### PR DESCRIPTION
We build and install openssl in /rustroot/ but the system's
TLS certificate chain is in /etc/pki/tls. This prevents
python from validating the certificates on https urls,
blocking tooltool and probably also why easy-install
was failing before we switched to pip. I guess all this
used to work only because python wasn't validating certs
in earlier 2.7 releases.

This wasn't a blocker because most of the image scripts
use curl for download. I assume--but haven't verified--
that this works because curl relies on the /etc/ path,
overriding the openssl default.
