### PR TITLE
Write cargo date file for use by v2 manifests

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1334,6 +1334,12 @@ def finish_dist(f, local_dist_dir, dist_subdirs, s3_addy, remote_dist_dir, compo
     f.addStep(MasterShellCommand(name="manifesting",
                                  command=["sh", "-c", WithProperties(manifest_cmd)]))
 
+    # Write cargo date
+    if "cargo" in component:
+        cargo_date_cmd = "date +\%Y-\%m-\%d > " + final_dist_dir + "/cargo-build-date.txt"
+        f.addStep(MasterShellCommand(name="Write date to cargo-build-date.txt",
+                                     command=["sh", "-c", cargo_date_cmd] ))
+
     # Generate signatures
     sign_cmd = "for i in " + final_dist_dir + "/* ; do gpg --no-tty --yes --passphrase-fd 0 -a --detach-sign $i < ../rust-bot-sign-passphrase; done"
     f.addStep(MasterShellCommand(name="signing",


### PR DESCRIPTION
This change has been working in dev. 