### PR TITLE
Openssl 1.0.2g

### DIFF
--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -6,7 +6,7 @@ VERSION=1.0.2f
 SHA256=932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
 
 yum install -y setarch
-curl http://openssl.org/source/openssl-$VERSION.tar.gz | \
+curl http://www.openssl.org/source/old/1.0.2/openssl-$VERSION.tar.gz | \
   tee >(sha256sum > openssl-$VERSION.tar.gz.sha256)    | tar xzf -
 test $SHA256 = $(cut -d ' ' -f 1 openssl-$VERSION.tar.gz.sha256) || exit 1
 

--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -2,11 +2,11 @@
 
 set -ex
 
-VERSION=1.0.2f
-SHA256=932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
+VERSION=1.0.2g
+SHA256=b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
 
 yum install -y setarch
-curl http://www.openssl.org/source/old/1.0.2/openssl-$VERSION.tar.gz | \
+curl http://openssl.org/source/openssl-$VERSION.tar.gz | \
   tee >(sha256sum > openssl-$VERSION.tar.gz.sha256)    | tar xzf -
 test $SHA256 = $(cut -d ' ' -f 1 openssl-$VERSION.tar.gz.sha256) || exit 1
 


### PR DESCRIPTION
The release notes indicate problems with key leaks, which
aren't significant for our use (downloading public data)
but it's still nice to be up to date. It also fixes some
crash bugs and issues with previous mitigation fixes.