### PR TITLE
Add support for Android NDK 16

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -817,7 +817,7 @@ class ConfigCommand(object):
 
         # Set up the path to the android NDK
         if testing_android:
-            s += " --android-cross-path=/android/ndk-arm-18"
+            s += " --android-cross-path=/android/ndk-arm-16"
             s += " --disable-docs"
 
         if "release-channel" in props:

--- a/slaves/android/install-ndk.sh
+++ b/slaves/android/install-ndk.sh
@@ -8,6 +8,13 @@ set -ex
 curl -O http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin
 chmod +x android-ndk-r10e-linux-x86_64.bin
 ./android-ndk-r10e-linux-x86_64.bin > /dev/null
+
+bash android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
+        --platform=android-16 \
+        --toolchain=arm-linux-androideabi-4.8 \
+        --install-dir=/android/ndk-arm-16 \
+        --ndk-dir=/android/android-ndk-r10e \
+        --arch=arm
 bash android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
         --platform=android-18 \
         --toolchain=arm-linux-androideabi-4.8 \


### PR DESCRIPTION
This PR adds support for Android NDK 16, as discussed in https://github.com/rust-lang/rust/issues/31119#issuecomment-192957651 :smile: 