### PR TITLE
Ints in buildbot.tac should not be strings

### DIFF
--- a/master/buildbot.tac
+++ b/master/buildbot.tac
@@ -4,8 +4,8 @@ from twisted.application import service
 from buildbot.master import BuildMaster
 
 basedir = '/home/rustbuild/rust-buildbot/master'
-rotateLength = '10000000'
-maxRotatedFiles = '10'
+rotateLength = 10000000
+maxRotatedFiles = 10
 configfile = 'master.cfg'
 
 # Default umask for server


### PR DESCRIPTION
```
ERROR: rotateLength is a string, it should be a number
ERROR: Please, edit your buildbot.tac file and run again
ERROR: See http://trac.buildbot.net/ticket/2588 for more details
```

Error shows up with buildbot 0.8.10; currently running version on prod master is `0.8.10-pre-86-g94ddde8`
