### PR TITLE
linux-cross: fix the `arm-linux-gnueabihf` toolchain

### DIFF
--- a/slaves/linux-cross/arm-linux-gnueabihf.config
+++ b/slaves/linux-cross/arm-linux-gnueabihf.config
@@ -104,7 +104,7 @@ CT_ARCH_DEFAULT_32=y
 CT_ARCH_ARCH="armv6"
 CT_ARCH_CPU=""
 CT_ARCH_TUNE=""
-CT_ARCH_FPU="vfpv3-d16"
+CT_ARCH_FPU="vfp"
 # CT_ARCH_BE is not set
 CT_ARCH_LE=y
 CT_ARCH_32=y
@@ -155,19 +155,13 @@ CT_ARCH_EXCLUSIVE_WITH_CPU=y
 # CT_ARCH_FLOAT_AUTO is not set
 # CT_ARCH_FLOAT_SOFTFP is not set
 CT_ARCH_FLOAT="hard"
-# CT_ARCH_ALPHA_EV4 is not set
-# CT_ARCH_ALPHA_EV45 is not set
-# CT_ARCH_ALPHA_EV5 is not set
-# CT_ARCH_ALPHA_EV56 is not set
-# CT_ARCH_ALPHA_EV6 is not set
-# CT_ARCH_ALPHA_EV67 is not set
 
 #
 # arm other options
 #
-CT_ARCH_ARM_MODE="thumb"
-# CT_ARCH_ARM_MODE_ARM is not set
-CT_ARCH_ARM_MODE_THUMB=y
+CT_ARCH_ARM_MODE="arm"
+CT_ARCH_ARM_MODE_ARM=y
+# CT_ARCH_ARM_MODE_THUMB is not set
 # CT_ARCH_ARM_INTERWORKING is not set
 CT_ARCH_ARM_EABI_FORCE=y
 CT_ARCH_ARM_EABI=y
@@ -311,8 +305,6 @@ CT_LIBC="glibc"
 CT_LIBC_VERSION="2.14.1"
 CT_LIBC_glibc=y
 # CT_LIBC_musl is not set
-# CT_LIBC_newlib is not set
-# CT_LIBC_none is not set
 # CT_LIBC_uClibc is not set
 CT_LIBC_avr_libc_AVAILABLE=y
 CT_LIBC_glibc_AVAILABLE=y


### PR DESCRIPTION
The toolchain fails to build with the current settings. This PR adjusts them to make the toolchain
buildable again.