### PR TITLE
linux-cross: add armv7-linux-gnu toolchain

### DIFF
--- a/slaves/linux-cross/Dockerfile
+++ b/slaves/linux-cross/Dockerfile
@@ -80,6 +80,19 @@ RUN /bin/bash build_toolchain.sh arm-linux-gnueabihf
 RUN /bin/bash build_toolchain.sh mips-linux-musl
 RUN /bin/bash build_toolchain.sh mipsel-linux-musl
 
+# Also build a toolchain tuned for the armv7 architecture which is going to be
+# used with the armv7-unknown-linux-gnueabihf target.
+#
+# Why are we not using the arm-linux-gnueabihf toolchain with the armv7 target?
+# We actually tried that setup but we hit `ar` errors caused by the different
+# codegen options used by crosstool-ng and the rust build system. crosstool-ng
+# uses `-march=armv6` to build the toolchain and related C(++) libraries, like
+# libstdc++ which gets statically linked to LLVM; on the other hand the rust
+# build system builds its C(++) libraries, like LLVM, with `-march=armv7-a`.
+#
+# By using this armv7 compiler we can ensure the same codegen options are used
+# everywhere and avoid these codegen mismatch issues. Also compiling libstdc++
+# for armv7 instead of for armv6 should make rustc (slightly) faster.
 RUN /bin/bash build_toolchain.sh armv7-linux-gnueabihf
 
 USER root

--- a/slaves/linux-cross/Dockerfile
+++ b/slaves/linux-cross/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:15.10
 
 RUN apt-get update
 RUN apt-get install -y --force-yes --no-install-recommends \
-        curl make git wget file \
+        curl make cmake git wget file \
         python-dev python-pip stunnel \
         g++ gcc libc6-dev \
         gcc-4.8-aarch64-linux-gnu libc6-dev-arm64-cross \
@@ -35,7 +35,7 @@ RUN /bin/bash build_rumprun.sh && rm -rf /build
 
 # Install buildbot and prep it to run
 RUN pip install buildbot-slave
-RUN groupadd -r rustbuild && useradd -r -g rustbuild rustbuild
+RUN groupadd -r rustbuild && useradd -m -r -g rustbuild rustbuild
 RUN mkdir /buildslave && chown rustbuild:rustbuild /buildslave
 
 # Build/install crosstool-ng cross compilers
@@ -53,6 +53,7 @@ COPY linux-cross/build_toolchain.sh \
     linux-cross/arm-linux-gnueabihf.config \
     linux-cross/mips-linux-musl.config \
     linux-cross/mipsel-linux-musl.config \
+    linux-cross/armv7-linux-gnueabihf.config \
     /build/
 USER rustbuild
 
@@ -79,6 +80,8 @@ RUN /bin/bash build_toolchain.sh arm-linux-gnueabihf
 RUN /bin/bash build_toolchain.sh mips-linux-musl
 RUN /bin/bash build_toolchain.sh mipsel-linux-musl
 
+RUN /bin/bash build_toolchain.sh armv7-linux-gnueabihf
+
 USER root
 RUN rm -rf /build
 
@@ -101,7 +104,17 @@ RUN                                               \
   for f in `ls /x-tools/mipsel-unknown-linux-musl/bin/mipsel-unknown-linux-musl-*`; do     \
     g=`basename $f`;  \
     ln -vs $f /usr/bin/`echo $g | sed -e 's/-unknown//'`;    \
+  done &&                                        \
+  for f in `ls /x-tools/armv7-unknown-linux-gnueabihf/bin/armv7-unknown-linux-gnueabihf-*`; do     \
+    g=`basename $f`;  \
+    ln -vs $f /usr/bin/`echo $g | sed -e 's/-unknown//'`;    \
   done
+
+# Instruct rustbuild to use the armv7-linux-gnueabihf toolchain instead of the default
+# arm-linux-gnueabihf one
+ENV AR_armv7_unknown_linux_gnueabihf=armv7-linux-gnueabihf-ar \
+  CC_armv7_unknown_linux_gnueabihf=armv7-linux-gnueabihf-gcc \
+  CXX_armv7_unknown_linux_gnueabihf=armv7-linux-gnueabihf-g++
 
 # When running this container, startup buildbot
 WORKDIR /buildslave

--- a/slaves/linux-cross/README.md
+++ b/slaves/linux-cross/README.md
@@ -91,7 +91,7 @@ For targets: `arm-unknown-linux-gnueabi`
 
 ## `arm-linux-gnueabihf.config`
 
-For targets: `arm-unknown-linux-gnueabihf`, `armv7-unknown-linux-gnueabihf`
+For targets: `arm-unknown-linux-gnueabihf`
 
 - Path and misc options > Prefix directory = /x-tools/${CT\_TARGET}
 - Target options > Target Architecture = arm
@@ -105,10 +105,27 @@ For targets: `arm-unknown-linux-gnueabihf`, `armv7-unknown-linux-gnueabihf`
 - C compiler > gcc version = 4.9.3
 - C compiler > C++ = ENABLE -- to cross compile LLVM
 
+## `armv7-linux-gnueabihf.config`
+
+For targets: `armv7-unknown-linux-gnueabihf`
+
+- Path and misc options > Prefix directory = /x-tools/${CT\_TARGET}
+- Target options > Target Architecture = arm
+- Target options > Suffix to the arch-part = v7
+- Target options > Architecture level = armv7-a -- (+)
+- Target options > Use specific FPU = vfpv3-d16 -- (\*)
+- Target options > Floating point = hardware (FPU) -- (\*)
+- Target options > Default instruction set mode = thumb -- (\*)
+- Operating System > Target OS = linux
+- Operating System > Linux kernel version = 3.2.72 -- Precise kernel
+- C-library > glibc version = 2.14.1
+- C compiler > gcc version = 4.9.3
+- C compiler > C++ = ENABLE -- to cross compile LLVM
+
 (\*) These options have been selected to match the configuration of the arm
       toolchains shipped with Ubuntu 15.10
 (+) These options have been selected to match the gcc flags we use to compile C
-    libraries like jemalloc. See the mk/cfg/arm-uknown-linux-gnueabi{,hf}.mk
+    libraries like jemalloc. See the mk/cfg/arm(v7)-uknown-linux-gnueabi{,hf}.mk
     file in Rust's source code.
 
 ## `mips-linux-musl.config`

--- a/slaves/linux-cross/armv7-linux-gnueabihf.config
+++ b/slaves/linux-cross/armv7-linux-gnueabihf.config
@@ -1,0 +1,562 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Crosstool-NG Configuration
+#
+CT_CONFIGURE_has_make381=y
+CT_CONFIGURE_has_xz=y
+CT_MODULES=y
+
+#
+# Paths and misc options
+#
+
+#
+# crosstool-NG behavior
+#
+# CT_OBSOLETE is not set
+# CT_EXPERIMENTAL is not set
+# CT_DEBUG_CT is not set
+
+#
+# Paths
+#
+CT_LOCAL_TARBALLS_DIR=""
+CT_WORK_DIR="${CT_TOP_DIR}/.build"
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_INSTALL_DIR="${CT_PREFIX_DIR}"
+CT_RM_RF_PREFIX_DIR=y
+CT_REMOVE_DOCS=y
+CT_INSTALL_DIR_RO=y
+CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
+# CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
+
+#
+# Downloading
+#
+# CT_FORBID_DOWNLOAD is not set
+# CT_FORCE_DOWNLOAD is not set
+CT_CONNECT_TIMEOUT=10
+# CT_ONLY_DOWNLOAD is not set
+# CT_USE_MIRROR is not set
+
+#
+# Extracting
+#
+# CT_FORCE_EXTRACT is not set
+CT_OVERIDE_CONFIG_GUESS_SUB=y
+# CT_ONLY_EXTRACT is not set
+CT_PATCH_BUNDLED=y
+# CT_PATCH_LOCAL is not set
+# CT_PATCH_BUNDLED_LOCAL is not set
+# CT_PATCH_LOCAL_BUNDLED is not set
+# CT_PATCH_BUNDLED_FALLBACK_LOCAL is not set
+# CT_PATCH_LOCAL_FALLBACK_BUNDLED is not set
+# CT_PATCH_NONE is not set
+CT_PATCH_ORDER="bundled"
+
+#
+# Build behavior
+#
+CT_PARALLEL_JOBS=0
+CT_LOAD=""
+CT_USE_PIPES=y
+CT_EXTRA_CFLAGS_FOR_BUILD=""
+CT_EXTRA_LDFLAGS_FOR_BUILD=""
+CT_EXTRA_CFLAGS_FOR_HOST=""
+CT_EXTRA_LDFLAGS_FOR_HOST=""
+# CT_CONFIG_SHELL_SH is not set
+# CT_CONFIG_SHELL_ASH is not set
+CT_CONFIG_SHELL_BASH=y
+# CT_CONFIG_SHELL_CUSTOM is not set
+CT_CONFIG_SHELL="${bash}"
+
+#
+# Logging
+#
+# CT_LOG_ERROR is not set
+# CT_LOG_WARN is not set
+CT_LOG_INFO=y
+# CT_LOG_EXTRA is not set
+# CT_LOG_ALL is not set
+# CT_LOG_DEBUG is not set
+CT_LOG_LEVEL_MAX="INFO"
+# CT_LOG_SEE_TOOLS_WARN is not set
+CT_LOG_PROGRESS_BAR=y
+CT_LOG_TO_FILE=y
+CT_LOG_FILE_COMPRESS=y
+
+#
+# Target options
+#
+CT_ARCH="arm"
+CT_ARCH_SUPPORTS_BOTH_MMU=y
+CT_ARCH_SUPPORTS_BOTH_ENDIAN=y
+CT_ARCH_SUPPORTS_32=y
+CT_ARCH_SUPPORTS_64=y
+CT_ARCH_SUPPORTS_WITH_ARCH=y
+CT_ARCH_SUPPORTS_WITH_CPU=y
+CT_ARCH_SUPPORTS_WITH_TUNE=y
+CT_ARCH_SUPPORTS_WITH_FLOAT=y
+CT_ARCH_SUPPORTS_WITH_FPU=y
+CT_ARCH_SUPPORTS_SOFTFP=y
+CT_ARCH_DEFAULT_HAS_MMU=y
+CT_ARCH_DEFAULT_LE=y
+CT_ARCH_DEFAULT_32=y
+CT_ARCH_ARCH="armv7-a"
+CT_ARCH_CPU=""
+CT_ARCH_TUNE=""
+CT_ARCH_FPU="vfpv3-d16"
+# CT_ARCH_BE is not set
+CT_ARCH_LE=y
+CT_ARCH_32=y
+# CT_ARCH_64 is not set
+CT_ARCH_BITNESS=32
+CT_ARCH_FLOAT_HW=y
+# CT_ARCH_FLOAT_SW is not set
+CT_TARGET_CFLAGS=""
+CT_TARGET_LDFLAGS=""
+# CT_ARCH_alpha is not set
+CT_ARCH_arm=y
+# CT_ARCH_avr is not set
+# CT_ARCH_m68k is not set
+# CT_ARCH_mips is not set
+# CT_ARCH_nios2 is not set
+# CT_ARCH_powerpc is not set
+# CT_ARCH_s390 is not set
+# CT_ARCH_sh is not set
+# CT_ARCH_sparc is not set
+# CT_ARCH_x86 is not set
+# CT_ARCH_xtensa is not set
+CT_ARCH_alpha_AVAILABLE=y
+CT_ARCH_arm_AVAILABLE=y
+CT_ARCH_avr_AVAILABLE=y
+CT_ARCH_m68k_AVAILABLE=y
+CT_ARCH_microblaze_AVAILABLE=y
+CT_ARCH_mips_AVAILABLE=y
+CT_ARCH_nios2_AVAILABLE=y
+CT_ARCH_powerpc_AVAILABLE=y
+CT_ARCH_s390_AVAILABLE=y
+CT_ARCH_sh_AVAILABLE=y
+CT_ARCH_sparc_AVAILABLE=y
+CT_ARCH_x86_AVAILABLE=y
+CT_ARCH_xtensa_AVAILABLE=y
+CT_ARCH_SUFFIX="v7"
+
+#
+# Generic target options
+#
+# CT_MULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ENDIAN="little"
+
+#
+# Target optimisations
+#
+CT_ARCH_EXCLUSIVE_WITH_CPU=y
+# CT_ARCH_FLOAT_AUTO is not set
+# CT_ARCH_FLOAT_SOFTFP is not set
+CT_ARCH_FLOAT="hard"
+
+#
+# arm other options
+#
+CT_ARCH_ARM_MODE="thumb"
+# CT_ARCH_ARM_MODE_ARM is not set
+CT_ARCH_ARM_MODE_THUMB=y
+# CT_ARCH_ARM_INTERWORKING is not set
+CT_ARCH_ARM_EABI_FORCE=y
+CT_ARCH_ARM_EABI=y
+CT_ARCH_ARM_TUPLE_USE_EABIHF=y
+
+#
+# Toolchain options
+#
+
+#
+# General toolchain options
+#
+CT_FORCE_SYSROOT=y
+CT_USE_SYSROOT=y
+CT_SYSROOT_NAME="sysroot"
+CT_SYSROOT_DIR_PREFIX=""
+CT_WANTS_STATIC_LINK=y
+# CT_STATIC_TOOLCHAIN is not set
+CT_TOOLCHAIN_PKGVERSION=""
+CT_TOOLCHAIN_BUGURL=""
+
+#
+# Tuple completion and aliasing
+#
+CT_TARGET_VENDOR="unknown"
+CT_TARGET_ALIAS_SED_EXPR=""
+CT_TARGET_ALIAS=""
+
+#
+# Toolchain type
+#
+CT_CROSS=y
+# CT_CANADIAN is not set
+CT_TOOLCHAIN_TYPE="cross"
+
+#
+# Build system
+#
+CT_BUILD=""
+CT_BUILD_PREFIX=""
+CT_BUILD_SUFFIX=""
+
+#
+# Misc options
+#
+# CT_TOOLCHAIN_ENABLE_NLS is not set
+
+#
+# Operating System
+#
+CT_KERNEL_SUPPORTS_SHARED_LIBS=y
+CT_KERNEL="linux"
+CT_KERNEL_VERSION="3.2.72"
+# CT_KERNEL_bare_metal is not set
+CT_KERNEL_linux=y
+CT_KERNEL_bare_metal_AVAILABLE=y
+CT_KERNEL_linux_AVAILABLE=y
+# CT_KERNEL_V_4_3 is not set
+# CT_KERNEL_V_4_2 is not set
+# CT_KERNEL_V_4_1 is not set
+# CT_KERNEL_V_3_18 is not set
+# CT_KERNEL_V_3_14 is not set
+# CT_KERNEL_V_3_12 is not set
+# CT_KERNEL_V_3_10 is not set
+# CT_KERNEL_V_3_4 is not set
+CT_KERNEL_V_3_2=y
+# CT_KERNEL_V_2_6_32 is not set
+# CT_KERNEL_LINUX_CUSTOM is not set
+CT_KERNEL_windows_AVAILABLE=y
+
+#
+# Common kernel options
+#
+CT_SHARED_LIBS=y
+
+#
+# linux other options
+#
+CT_KERNEL_LINUX_VERBOSITY_0=y
+# CT_KERNEL_LINUX_VERBOSITY_1 is not set
+# CT_KERNEL_LINUX_VERBOSITY_2 is not set
+CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+CT_KERNEL_LINUX_INSTALL_CHECK=y
+
+#
+# Binary utilities
+#
+CT_ARCH_BINFMT_ELF=y
+CT_BINUTILS="binutils"
+CT_BINUTILS_binutils=y
+
+#
+# GNU binutils
+#
+# CT_CC_BINUTILS_SHOW_LINARO is not set
+CT_BINUTILS_V_2_25_1=y
+# CT_BINUTILS_V_2_25 is not set
+# CT_BINUTILS_V_2_24 is not set
+# CT_BINUTILS_V_2_23_2 is not set
+# CT_BINUTILS_V_2_23_1 is not set
+# CT_BINUTILS_V_2_22 is not set
+# CT_BINUTILS_V_2_21_53 is not set
+# CT_BINUTILS_V_2_21_1a is not set
+# CT_BINUTILS_V_2_20_1a is not set
+# CT_BINUTILS_V_2_19_1a is not set
+# CT_BINUTILS_V_2_18a is not set
+CT_BINUTILS_VERSION="2.25.1"
+CT_BINUTILS_2_25_1_or_later=y
+CT_BINUTILS_2_25_or_later=y
+CT_BINUTILS_2_24_or_later=y
+CT_BINUTILS_2_23_or_later=y
+CT_BINUTILS_2_22_or_later=y
+CT_BINUTILS_2_21_or_later=y
+CT_BINUTILS_2_20_or_later=y
+CT_BINUTILS_2_19_or_later=y
+CT_BINUTILS_2_18_or_later=y
+CT_BINUTILS_HAS_HASH_STYLE=y
+CT_BINUTILS_HAS_GOLD=y
+CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
+CT_BINUTILS_GOLD_SUPPORT=y
+CT_BINUTILS_HAS_PLUGINS=y
+CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
+CT_BINUTILS_FORCE_LD_BFD=y
+CT_BINUTILS_LINKER_LD=y
+# CT_BINUTILS_LINKER_LD_GOLD is not set
+# CT_BINUTILS_LINKER_GOLD_LD is not set
+CT_BINUTILS_LINKERS_LIST="ld"
+CT_BINUTILS_LINKER_DEFAULT="bfd"
+# CT_BINUTILS_PLUGINS is not set
+CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
+# CT_BINUTILS_FOR_TARGET is not set
+
+#
+# binutils other options
+#
+
+#
+# C-library
+#
+CT_LIBC="glibc"
+CT_LIBC_VERSION="2.14.1"
+CT_LIBC_glibc=y
+# CT_LIBC_musl is not set
+# CT_LIBC_uClibc is not set
+CT_LIBC_avr_libc_AVAILABLE=y
+CT_LIBC_glibc_AVAILABLE=y
+CT_THREADS="nptl"
+# CT_CC_GLIBC_SHOW_LINARO is not set
+# CT_LIBC_GLIBC_V_2_22 is not set
+# CT_LIBC_GLIBC_V_2_21 is not set
+# CT_LIBC_GLIBC_V_2_20 is not set
+# CT_LIBC_GLIBC_V_2_19 is not set
+# CT_LIBC_GLIBC_V_2_18 is not set
+# CT_LIBC_GLIBC_V_2_17 is not set
+# CT_LIBC_GLIBC_V_2_16_0 is not set
+# CT_LIBC_GLIBC_V_2_15 is not set
+CT_LIBC_GLIBC_V_2_14_1=y
+# CT_LIBC_GLIBC_V_2_14 is not set
+# CT_LIBC_GLIBC_V_2_13 is not set
+# CT_LIBC_GLIBC_V_2_12_2 is not set
+# CT_LIBC_GLIBC_V_2_12_1 is not set
+# CT_LIBC_GLIBC_V_2_11_1 is not set
+# CT_LIBC_GLIBC_V_2_11 is not set
+# CT_LIBC_GLIBC_V_2_10_1 is not set
+# CT_LIBC_GLIBC_V_2_9 is not set
+# CT_LIBC_GLIBC_V_2_8 is not set
+CT_LIBC_mingw_AVAILABLE=y
+CT_LIBC_musl_AVAILABLE=y
+CT_LIBC_newlib_AVAILABLE=y
+CT_LIBC_none_AVAILABLE=y
+CT_LIBC_uClibc_AVAILABLE=y
+CT_LIBC_SUPPORT_THREADS_ANY=y
+CT_LIBC_SUPPORT_THREADS_NATIVE=y
+
+#
+# Common C library options
+#
+CT_THREADS_NATIVE=y
+CT_LIBC_XLDD=y
+
+#
+# glibc other options
+#
+CT_LIBC_GLIBC_PORTS_EXTERNAL=y
+CT_LIBC_GLIBC_MAY_FORCE_PORTS=y
+CT_LIBC_glibc_familly=y
+CT_LIBC_GLIBC_EXTRA_CONFIG_ARRAY=""
+CT_LIBC_GLIBC_CONFIGPARMS=""
+CT_LIBC_GLIBC_EXTRA_CFLAGS=""
+CT_LIBC_EXTRA_CC_ARGS=""
+# CT_LIBC_DISABLE_VERSIONING is not set
+CT_LIBC_OLDEST_ABI=""
+CT_LIBC_GLIBC_FORCE_UNWIND=y
+CT_LIBC_GLIBC_USE_PORTS=y
+CT_LIBC_ADDONS_LIST=""
+
+#
+# WARNING !!!                                            
+#
+
+#
+#   For glibc >= 2.8, it can happen that the tarballs    
+#
+
+#
+#   for the addons are not available for download.       
+#
+
+#
+#   If that happens, bad luck... Try a previous version  
+#
+
+#
+#   or try again later... :-(                            
+#
+# CT_LIBC_LOCALES is not set
+# CT_LIBC_GLIBC_KERNEL_VERSION_NONE is not set
+CT_LIBC_GLIBC_KERNEL_VERSION_AS_HEADERS=y
+# CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN is not set
+CT_LIBC_GLIBC_MIN_KERNEL="3.2.72"
+
+#
+# C compiler
+#
+CT_CC="gcc"
+CT_CC_CORE_PASSES_NEEDED=y
+CT_CC_CORE_PASS_1_NEEDED=y
+CT_CC_CORE_PASS_2_NEEDED=y
+CT_CC_gcc=y
+# CT_CC_GCC_SHOW_LINARO is not set
+# CT_CC_GCC_V_5_2_0 is not set
+CT_CC_GCC_V_4_9_3=y
+# CT_CC_GCC_V_4_8_5 is not set
+# CT_CC_GCC_V_4_7_4 is not set
+# CT_CC_GCC_V_4_6_4 is not set
+# CT_CC_GCC_V_4_5_4 is not set
+# CT_CC_GCC_V_4_4_7 is not set
+# CT_CC_GCC_V_4_3_6 is not set
+# CT_CC_GCC_V_4_2_4 is not set
+CT_CC_GCC_4_2_or_later=y
+CT_CC_GCC_4_3_or_later=y
+CT_CC_GCC_4_4_or_later=y
+CT_CC_GCC_4_5_or_later=y
+CT_CC_GCC_4_6_or_later=y
+CT_CC_GCC_4_7_or_later=y
+CT_CC_GCC_4_8_or_later=y
+CT_CC_GCC_4_9=y
+CT_CC_GCC_4_9_or_later=y
+CT_CC_GCC_HAS_GRAPHITE=y
+CT_CC_GCC_USE_GRAPHITE=y
+CT_CC_GCC_HAS_LTO=y
+CT_CC_GCC_USE_LTO=y
+CT_CC_GCC_HAS_PKGVERSION_BUGURL=y
+CT_CC_GCC_HAS_BUILD_ID=y
+CT_CC_GCC_HAS_LNK_HASH_STYLE=y
+CT_CC_GCC_USE_GMP_MPFR=y
+CT_CC_GCC_USE_MPC=y
+CT_CC_GCC_HAS_LIBQUADMATH=y
+CT_CC_GCC_HAS_LIBSANITIZER=y
+CT_CC_GCC_VERSION="4.9.3"
+# CT_CC_LANG_FORTRAN is not set
+CT_CC_GCC_ENABLE_CXX_FLAGS=""
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY=""
+CT_CC_GCC_EXTRA_CONFIG_ARRAY=""
+CT_CC_GCC_EXTRA_ENV_ARRAY=""
+CT_CC_GCC_STATIC_LIBSTDCXX=y
+# CT_CC_GCC_SYSTEM_ZLIB is not set
+
+#
+# Optimisation features
+#
+
+#
+# Settings for libraries running on target
+#
+CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
+# CT_CC_GCC_LIBMUDFLAP is not set
+# CT_CC_GCC_LIBGOMP is not set
+# CT_CC_GCC_LIBSSP is not set
+# CT_CC_GCC_LIBQUADMATH is not set
+# CT_CC_GCC_LIBSANITIZER is not set
+
+#
+# Misc. obscure options.
+#
+CT_CC_CXA_ATEXIT=y
+# CT_CC_GCC_DISABLE_PCH is not set
+CT_CC_GCC_SJLJ_EXCEPTIONS=m
+CT_CC_GCC_LDBL_128=m
+# CT_CC_GCC_BUILD_ID is not set
+CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
+# CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
+# CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
+# CT_CC_GCC_LNK_HASH_STYLE_BOTH is not set
+CT_CC_GCC_LNK_HASH_STYLE=""
+CT_CC_GCC_DEC_FLOAT_AUTO=y
+# CT_CC_GCC_DEC_FLOAT_BID is not set
+# CT_CC_GCC_DEC_FLOAT_DPD is not set
+# CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_CC_SUPPORT_CXX=y
+CT_CC_SUPPORT_FORTRAN=y
+CT_CC_SUPPORT_JAVA=y
+CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_OBJC=y
+CT_CC_SUPPORT_OBJCXX=y
+CT_CC_SUPPORT_GOLANG=y
+
+#
+# Additional supported languages:
+#
+CT_CC_LANG_CXX=y
+# CT_CC_LANG_JAVA is not set
+
+#
+# Debug facilities
+#
+# CT_DEBUG_dmalloc is not set
+# CT_DEBUG_duma is not set
+# CT_DEBUG_gdb is not set
+# CT_DEBUG_ltrace is not set
+# CT_DEBUG_strace is not set
+
+#
+# Companion libraries
+#
+CT_COMPLIBS_NEEDED=y
+CT_LIBICONV_NEEDED=y
+CT_GETTEXT_NEEDED=y
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_CLOOG_NEEDED=y
+CT_MPC_NEEDED=y
+CT_COMPLIBS=y
+CT_LIBICONV=y
+CT_GETTEXT=y
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_CLOOG=y
+CT_MPC=y
+CT_LIBICONV_V_1_14=y
+CT_LIBICONV_VERSION="1.14"
+CT_GETTEXT_V_0_19_6=y
+CT_GETTEXT_VERSION="0.19.6"
+CT_GMP_V_6_0_0=y
+# CT_GMP_V_5_1_3 is not set
+# CT_GMP_V_5_1_1 is not set
+# CT_GMP_V_5_0_2 is not set
+# CT_GMP_V_5_0_1 is not set
+# CT_GMP_V_4_3_2 is not set
+# CT_GMP_V_4_3_1 is not set
+# CT_GMP_V_4_3_0 is not set
+CT_GMP_5_0_2_or_later=y
+CT_GMP_VERSION="6.0.0a"
+CT_MPFR_V_3_1_3=y
+# CT_MPFR_V_3_1_2 is not set
+# CT_MPFR_V_3_1_0 is not set
+# CT_MPFR_V_3_0_1 is not set
+# CT_MPFR_V_3_0_0 is not set
+# CT_MPFR_V_2_4_2 is not set
+# CT_MPFR_V_2_4_1 is not set
+# CT_MPFR_V_2_4_0 is not set
+CT_MPFR_VERSION="3.1.3"
+CT_ISL_V_0_14=y
+CT_ISL_V_0_14_or_later=y
+CT_ISL_V_0_12_or_later=y
+CT_ISL_VERSION="0.14"
+CT_CLOOG_V_0_18_4=y
+# CT_CLOOG_V_0_18_1 is not set
+# CT_CLOOG_V_0_18_0 is not set
+CT_CLOOG_VERSION="0.18.4"
+CT_CLOOG_0_18_4_or_later=y
+CT_CLOOG_0_18_or_later=y
+CT_MPC_V_1_0_3=y
+# CT_MPC_V_1_0_2 is not set
+# CT_MPC_V_1_0_1 is not set
+# CT_MPC_V_1_0 is not set
+# CT_MPC_V_0_9 is not set
+# CT_MPC_V_0_8_2 is not set
+# CT_MPC_V_0_8_1 is not set
+# CT_MPC_V_0_7 is not set
+CT_MPC_VERSION="1.0.3"
+
+#
+# Companion libraries common options
+#
+# CT_COMPLIBS_CHECK is not set
+
+#
+# Companion tools
+#
+
+#
+# READ HELP before you say 'Y' below !!!
+#
+# CT_COMP_TOOLS is not set


### PR DESCRIPTION
When using rustbuild to build libstd/rustc for the armv7-unknown-linux-gnueabihf target we use this
toolchain instead of the arm-linux-gnueabihf one.

This commit also installs cmake and gives a home directory to the rustbuild user. Both are required
to be able to use rustbuild to cross compile rustc within this image.

r? @alexcrichton 