### PR TITLE
linux: build musl/libunwind for i686

### DIFF
--- a/slaves/linux/build-musl.sh
+++ b/slaves/linux/build-musl.sh
@@ -31,7 +31,8 @@ make -j10
 cp lib/libunwind.a /musl-x86_64/lib
 
 # (Note: the next cmake call doesn't fully override the previous cached one, so remove the cached
-# configuration manually)
+# configuration manually. IOW, if don't do this or call make clean we'll end up building libunwind
+# for x86_64 again)
 rm -rf *
 # for i686
 CFLAGS="$CFLAGS -m32" CXXFLAGS="$CXXFLAGS -m32" cmake /build/libunwind-3.7.0.src \

--- a/slaves/linux/build-musl.sh
+++ b/slaves/linux/build-musl.sh
@@ -8,7 +8,7 @@ export CFLAGS=-fPIC
 curl http://www.musl-libc.org/releases/musl-1.1.11.tar.gz | tar xzf -
 cd musl-1.1.11
 # for x86_64
-./configure --prefix=/musl --disable-shared
+./configure --prefix=/musl-x86_64 --disable-shared
 make -j10
 make install
 make clean
@@ -28,7 +28,7 @@ cd libunwind-build
 cmake ../libunwind-3.7.0.src -DLLVM_PATH=/build/llvm-3.7.0.src \
           -DLIBUNWIND_ENABLE_SHARED=0
 make -j10
-cp lib/libunwind.a /musl/lib
+cp lib/libunwind.a /musl-x86_64/lib
 
 # (Note: the next cmake call doesn't fully override the previous cached one, so remove the cached
 # configuration manually)

--- a/slaves/linux/build-musl.sh
+++ b/slaves/linux/build-musl.sh
@@ -7,7 +7,13 @@ export CFLAGS=-fPIC
 # Support building MUSL
 curl http://www.musl-libc.org/releases/musl-1.1.11.tar.gz | tar xzf -
 cd musl-1.1.11
+# for x86_64
 ./configure --prefix=/musl --disable-shared
+make -j10
+make install
+make clean
+# for i686
+CFLAGS="$CFLAGS -m32" ./configure --prefix=/musl-i686 --disable-shared --target=i686
 make -j10
 make install
 cd ..
@@ -18,7 +24,18 @@ curl http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz | tar xJf -
 curl http://llvm.org/releases/3.7.0/libunwind-3.7.0.src.tar.xz | tar xJf -
 mkdir libunwind-build
 cd libunwind-build
+# for x86_64
 cmake ../libunwind-3.7.0.src -DLLVM_PATH=/build/llvm-3.7.0.src \
           -DLIBUNWIND_ENABLE_SHARED=0
 make -j10
 cp lib/libunwind.a /musl/lib
+
+# (Note: the next cmake call doesn't fully override the previous cached one, so remove the cached
+# configuration manually)
+rm -rf *
+# for i686
+CFLAGS="$CFLAGS -m32" CXXFLAGS="$CXXFLAGS -m32" cmake /build/libunwind-3.7.0.src \
+          -DLLVM_PATH=/build/llvm-3.7.0.src \
+          -DLIBUNWIND_ENABLE_SHARED=0
+make -j10
+cp lib/libunwind.a /musl-i686/lib


### PR DESCRIPTION
Now we can use the "linux" docker image to build libstd for i686-unknown-linux-musl with the
following command:

configure --disable-rustbuild --musl-root=/musl-i686 --target=i686-unknown-linux-musl && make

r? @alexcrichton 