### PR TITLE
linux: use latest musl, fixes crt1.o -fPIC errors

### DIFF
--- a/slaves/linux/build-musl.sh
+++ b/slaves/linux/build-musl.sh
@@ -3,10 +3,10 @@
 set -ex
 
 export CFLAGS=-fPIC
-
+MUSL=musl-1.1.14
 # Support building MUSL
-curl http://www.musl-libc.org/releases/musl-1.1.11.tar.gz | tar xzf -
-cd musl-1.1.11
+curl http://www.musl-libc.org/releases/$MUSL.tar.gz | tar xzf -
+cd $MUSL
 # for x86_64
 ./configure --prefix=/musl-x86_64 --disable-shared
 make -j10


### PR DESCRIPTION
Later musl `Makefile` obey the `CFLAGS` w.r.t. the c runtime object files (i.e., the `_start` symbol), whereas `1.1.11` does not.

(also `1.1.11` is pretty old, and later releases pick up some security goodness).

Without this, when linking against `1.1.11` musl's `crt1.o` with something like:

```
rustc --target=x86_64-unknown-linux-musl -C link-args="-Wl,-pie,-I/usr/lib/ld-linux-x86-64.so.2" main.rs
```

You'll see this error:

```
note: /usr/bin/ld: /usr/local/lib/rustlib/x86_64-unknown-linux-musl/lib/crt1.o: relocation R_X86_64_32S against `_fini' can not be used when making a shared object; recompile with -fPIC
```

**NOTE**: with an `-fPIC` `crt1.o` and `libc`, rust with the musl target can now build "static" PIEs, in that they have a program interpreter (a dynamic linker), are shared objects, have an entry point --- a requirement for android M --- but which have _zero_ dynamic library dependencies (i.e., they've been completely statically linked).