### PR TITLE
Lotsa compilers

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -656,6 +656,8 @@ class MakeCommand(object):
     implements(IRenderable)
     def getRenderingFor(self, props):
         if "buildername" in props:
+            if "linux" in props["buildername"]:
+                return "make"
             if "bsd" in props["buildername"] or "bitrig" in props["buildername"]:
                 return "gmake"
             if "win" in props["buildername"]:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1727,6 +1727,7 @@ for p in dist_platforms:
 
     for channel in ['nightly', 'beta', 'stable']:
         my_targets = targets[:]
+        my_hosts = hosts
         rustbuild = None
         if "cross-linux" in p:
             if channel == 'beta':
@@ -1735,7 +1736,7 @@ for p in dist_platforms:
                 rustbuild = True
                 my_targets += nightly_lincross_targets
                 my_targets += beta_lincross_targets
-                hosts = [
+                my_hosts = [
                   "arm-unknown-linux-gnueabi",
                   "arm-unknown-linux-gnueabihf",
                   "armv7-unknown-linux-gnueabihf",
@@ -1750,7 +1751,7 @@ for p in dist_platforms:
                 category="util-dist",
                 properties={"platform":p,
                             "branch":branch,
-                            "hosts": hosts,
+                            "hosts": my_hosts,
                             "targets": my_targets,
                             "build": auto_platform_build(p),
                             "valgrind": False,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -132,6 +132,8 @@ auto_platforms = [
     #"linux-all-opt",
 
     "linux-64-x-android-t",
+    "linux-64-x-bsds",
+    "linux-64-x-arms",
 
     "win-gnu-32-opt",
     #"win-gnu-32-nopt-c",
@@ -191,16 +193,16 @@ nogate_builders = [
     "auto-dragonflybsd-64-opt",
     "auto-openbsd-64-opt",
     "auto-mac-64-opt-rustbuild",
-    #"auto-linux-64-opt-rustbuild",
-    #"auto-win-gnu-32-opt-rustbuild",
-    #"auto-win-msvc-64-opt-rustbuild",
+    "auto-linux-64-x-arms",
+    "auto-linux-64-x-bsds",
 ]
 dist_nogate_platforms = [
-    "cross-linux",
     "mac-ios",
 ]
 
 nightly_lincross_targets = [
+  'mips-unknown-linux-musl',
+  'mipsel-unknown-linux-musl',
 ]
 beta_lincross_targets = [
   'armv7-unknown-linux-gnueabihf',
@@ -1537,12 +1539,12 @@ c['builders'] = []
 
 def platform_slaves(p):
     # The android builder has one slave, with the same name
-    if "-x-" in p:
+    if "-x-android" in p:
         return [p]
 
     if "musl" in p:
         p = "linux"
-    elif "linux-cross" in p:
+    elif "linux-cross" in p or "linux-64-x-" in p:
         p = "lincross"
     elif "ios" in p:
         return [slave.slavename for slave in ios_slaves]
@@ -1619,6 +1621,7 @@ for p in auto_platforms:
 
     musl = None
     targets = []
+    hosts = auto_platform_host(p)
     if "-all" in p:
         chk = "check-lite"
     if "bsd" in p:
@@ -1648,6 +1651,17 @@ for p in auto_platforms:
             # Only test android, not the host
             chk = "check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu"
 
+    if "linux-64-x-" in p:
+        chk = False
+        if "bsds" in p:
+            hosts.append('x86_64-unknown-netbsd')
+            hosts.append('x86_64-unknown-freebsd')
+        if "arms" in p:
+            hosts.append('arm-unknown-linux-gnueabi')
+            hosts.append('arm-unknown-linux-gnueabihf')
+            hosts.append('armv7-unknown-linux-gnueabihf')
+        rustbuild = True
+
     c['builders'].append(BuilderConfig(
             mergeRequests=True,
             name="auto-" + p,
@@ -1662,7 +1676,7 @@ for p in auto_platforms:
                         "android": android,
                         "musl": musl,
                         "build": auto_platform_build(p),
-                        "hosts": auto_platform_host(p),
+                        "hosts": hosts,
                         "targets": targets,
                         "debug": debug,
                         "debug-assertions": True,
@@ -1710,12 +1724,21 @@ for p in dist_platforms:
 
     for channel in ['nightly', 'beta', 'stable']:
         my_targets = targets[:]
+        rustbuild = False
         if "cross-linux" in p:
+            rustbuild = True
             if channel == 'beta':
                 my_targets += beta_lincross_targets
             elif channel == 'nightly':
                 my_targets += nightly_lincross_targets
                 my_targets += beta_lincross_targets
+                hosts = [
+                  "arm-unknown-linux-gnueabi",
+                  "arm-unknown-linux-gnueabihf",
+                  "armv7-unknown-linux-gnueabihf",
+                  "x86_64-unknown-netbsd",
+                  "x86_64-unknown-freebsd",
+                ]
 
         branch = 'master' if channel == 'nightly' else channel
         c['builders'].append(BuilderConfig(
@@ -1731,7 +1754,8 @@ for p in dist_platforms:
                             "check": True,
                             "android": android,
                             "musl": musl,
-                            "llvm-static-stdcpp": p == 'linux',
+                            "llvm-static-stdcpp": 'linux' in p,
+                            "rustbuild": rustbuild,
                             "release-channel": channel},
                 nextSlave=nextSlave,
                 slavenames=platform_dist_slaves(p),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -203,6 +203,14 @@ dist_nogate_platforms = [
     "cross-host-linux",
 ]
 
+cross_host_targets = [
+  {'target': 'arm-unknown-linux-gnueabi', 'builder': 'armsf'},
+  {'target': 'arm-unknown-linux-gnueabihf', 'builder': 'armhf'},
+  {'target': 'armv7-unknown-linux-gnueabihf', 'builder': None},
+  {'target': 'x86_64-unknown-freebsd', 'builder': 'freebsd'},
+  {'target': 'x86_64-unknown-netbsd', 'builder': 'netbsd'},
+]
+
 nightly_lincross_targets = [
   'mips-unknown-linux-musl',
   'mipsel-unknown-linux-musl',
@@ -1660,16 +1668,11 @@ for p in auto_platforms:
             # Only test android, not the host
             chk = "check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu"
 
-    if "linux-64-x-" in p:
+    elif "linux-64-x-" in p:
         chk = False
-        if "netbsd" in p:
-            hosts.append('x86_64-unknown-netbsd')
-        if "freebsd" in p:
-            hosts.append('x86_64-unknown-freebsd')
-        if "armsf" in p:
-            hosts.append('arm-unknown-linux-gnueabi')
-        if "armhf" in p:
-            hosts.append('arm-unknown-linux-gnueabihf')
+        for target in cross_host_targets:
+            if target['builder'] in p:
+                hosts.append(target['target'])
         rustbuild = True
 
     c['builders'].append(BuilderConfig(
@@ -1744,13 +1747,7 @@ for p in dist_platforms:
                 my_targets += beta_lincross_targets
         if "cross-host-linux" in p:
             rustbuild = True
-            my_hosts = [
-              "arm-unknown-linux-gnueabi",
-              "arm-unknown-linux-gnueabihf",
-              "armv7-unknown-linux-gnueabihf",
-              "x86_64-unknown-netbsd",
-              "x86_64-unknown-freebsd",
-            ]
+            my_hosts = [h['target'] for h in cross_host_targets]
 
         branch = 'master' if channel == 'nightly' else channel
         c['builders'].append(BuilderConfig(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1250,7 +1250,10 @@ def distsnap_buildfactory(platform, channel_label):
                                  command=["sh", "-c", rm_dist_cmd]))
 
     # Upload artifacts from slave
-    f.addStep(DirectoryUpload(slavesrc="dist",
+    slave_dist_dir = "dist"
+    if 'cross-linux' in platform and channel_label == 'nightly':
+        slave_dist_dir = "build/dist"
+    f.addStep(DirectoryUpload(slavesrc=slave_dist_dir,
                               masterdest=local_dist_platform_dir,
                               workdir=BUILD_WORKDIR))
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -159,7 +159,9 @@ try_platforms = ["linux", "win-gnu-32", "win-gnu-64", "mac"]
 snap_platforms = ["linux", "win-gnu-32", "win-gnu-64", "mac", "bitrig-64",
                   "freebsd10_32-1", "freebsd10_64-1", "dragonflybsd-64-opt",
                   "openbsd-64-opt"]
-dist_platforms = ["linux", "mac", "arm-android", "musl-linux", "cross-linux",
+dist_platforms = ["linux", "mac", "arm-android", "musl-linux",
+                  "cross-linux",
+                  "cross-host-linux",
                   "mac-ios",
                   "win-gnu-32", "win-gnu-64",
                   "win-msvc-32", "win-msvc-64"]
@@ -198,6 +200,7 @@ nogate_builders = [
 ]
 dist_nogate_platforms = [
     "mac-ios",
+    "cross-host-linux",
 ]
 
 nightly_lincross_targets = [
@@ -1223,7 +1226,7 @@ def distsnap_buildfactory(platform, channel_label):
         command.append("check-stage2-T-x86_64-unknown-linux-musl-" + \
                        "H-x86_64-unknown-linux-gnu")
         command.append('dist')
-    elif 'cross-linux' in platform or 'ios' in platform:
+    elif 'cross' in platform or 'ios' in platform:
         command.append('dist')
     else:
         command.append('distcheck')
@@ -1251,7 +1254,7 @@ def distsnap_buildfactory(platform, channel_label):
 
     # Upload artifacts from slave
     slave_dist_dir = "dist"
-    if 'cross-linux' in platform and channel_label == 'nightly':
+    if 'cross-host-linux' in platform and channel_label == 'nightly':
         slave_dist_dir = "build/dist"
     f.addStep(DirectoryUpload(slavesrc=slave_dist_dir,
                               masterdest=local_dist_platform_dir,
@@ -1736,16 +1739,17 @@ for p in dist_platforms:
             if channel == 'beta':
                 my_targets += beta_lincross_targets
             elif channel == 'nightly':
-                rustbuild = True
                 my_targets += nightly_lincross_targets
                 my_targets += beta_lincross_targets
-                my_hosts = [
-                  "arm-unknown-linux-gnueabi",
-                  "arm-unknown-linux-gnueabihf",
-                  "armv7-unknown-linux-gnueabihf",
-                  "x86_64-unknown-netbsd",
-                  "x86_64-unknown-freebsd",
-                ]
+        if "cross-host-linux" in p:
+            rustbuild = True
+            my_hosts = [
+              "arm-unknown-linux-gnueabi",
+              "arm-unknown-linux-gnueabihf",
+              "armv7-unknown-linux-gnueabihf",
+              "x86_64-unknown-netbsd",
+              "x86_64-unknown-freebsd",
+            ]
 
         branch = 'master' if channel == 'nightly' else channel
         c['builders'].append(BuilderConfig(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -173,8 +173,8 @@ cargo_platforms = ["linux-32", "linux-64", "mac-32", "mac-64",
 cargo_dist_platforms = [p for p in cargo_platforms if "linux" in p or "mac" in p or "win" in p]
 
 def works_in_dev(platform):
-    return 'bsd' not in platform and \
-          'bitrig' not in platform
+    return 'linux' in platform or \
+      ('bsd' not in platform and 'bitrig' not in platform)
 
 if env != "prod":
     auto_platforms = [p for p in auto_platforms if works_in_dev(p)]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -132,8 +132,10 @@ auto_platforms = [
     #"linux-all-opt",
 
     "linux-64-x-android-t",
-    "linux-64-x-bsds",
-    "linux-64-x-arms",
+    "linux-64-x-netbsd",
+    "linux-64-x-freebsd",
+    "linux-64-x-armsf",
+    "linux-64-x-armhf",
 
     "win-gnu-32-opt",
     #"win-gnu-32-nopt-c",
@@ -195,8 +197,6 @@ nogate_builders = [
     "auto-dragonflybsd-64-opt",
     "auto-openbsd-64-opt",
     "auto-mac-64-opt-rustbuild",
-    "auto-linux-64-x-arms",
-    "auto-linux-64-x-bsds",
 ]
 dist_nogate_platforms = [
     "mac-ios",
@@ -1662,13 +1662,14 @@ for p in auto_platforms:
 
     if "linux-64-x-" in p:
         chk = False
-        if "bsds" in p:
+        if "netbsd" in p:
             hosts.append('x86_64-unknown-netbsd')
+        if "freebsd" in p:
             hosts.append('x86_64-unknown-freebsd')
-        if "arms" in p:
+        if "armsf" in p:
             hosts.append('arm-unknown-linux-gnueabi')
+        if "armhf" in p:
             hosts.append('arm-unknown-linux-gnueabihf')
-            hosts.append('armv7-unknown-linux-gnueabihf')
         rustbuild = True
 
     c['builders'].append(BuilderConfig(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -811,10 +811,11 @@ class ConfigCommand(object):
 
         for opt in opts:
             if opt in props:
-                if props_has_negative_key(props, opt):
-                    s += " --disable-" + opt
-                else:
-                    s += " --enable-" + opt
+                if props[opt] is not None:
+                    if props_has_negative_key(props, opt):
+                        s += " --disable-" + opt
+                    else:
+                        s += " --enable-" + opt
 
         if "musl" in props and props["musl"]:
             s += " --musl-root=" + props["musl"]
@@ -1605,7 +1606,7 @@ for p in auto_platforms:
     opt_tests = True
     debug = False
     chk = True
-    rustbuild = False
+    rustbuild = None
 
     if "-debug" in p:
         debug = True
@@ -1726,12 +1727,12 @@ for p in dist_platforms:
 
     for channel in ['nightly', 'beta', 'stable']:
         my_targets = targets[:]
-        rustbuild = False
+        rustbuild = None
         if "cross-linux" in p:
-            rustbuild = True
             if channel == 'beta':
                 my_targets += beta_lincross_targets
             elif channel == 'nightly':
+                rustbuild = True
                 my_targets += nightly_lincross_targets
                 my_targets += beta_lincross_targets
                 hosts = [

--- a/slaves/linux-cross/Dockerfile
+++ b/slaves/linux-cross/Dockerfile
@@ -5,16 +5,16 @@ RUN apt-get install -y --force-yes --no-install-recommends \
         curl make cmake git wget file \
         python-dev python-pip stunnel \
         bzip2 xz-utils \
-        g++ gcc libc6-dev \
-        gcc-4.8-aarch64-linux-gnu libc6-dev-arm64-cross \
-        gcc-4.8-powerpc-linux-gnu libc6-dev-powerpc-cross \
-        gcc-4.8-powerpc64le-linux-gnu libc6-dev-ppc64el-cross \
+        g++ libc6-dev \
+        g++-4.8-aarch64-linux-gnu libc6-dev-arm64-cross \
+        g++-4.8-powerpc-linux-gnu libc6-dev-powerpc-cross \
+        g++-4.8-powerpc64le-linux-gnu libc6-dev-ppc64el-cross \
         lib64gcc-4.8-dev-powerpc-cross libc6-dev-ppc64-powerpc-cross \
         software-properties-common
 RUN add-apt-repository ppa:angelsl/mips-cross && apt-get update
 RUN apt-get install -y --force-yes --no-install-recommends \
-        gcc-5-mips-linux-gnu libc6-dev-mips-cross \
-        gcc-5-mipsel-linux-gnu libc6-dev-mipsel-cross
+        g++-5-mips-linux-gnu libc6-dev-mips-cross \
+        g++-5-mipsel-linux-gnu libc6-dev-mipsel-cross
 
 # Rename compilers to variants without version numbers so the build
 # configuration in the standard library can pick them up.


### PR DESCRIPTION
These commits do a few things:

* Three new auto builders are created:
  * `linux-64-x-netbsd` - tests cross compiling from Linux to NetBSD
  * `linux-64-x-freebsd` - tests cross compiling from Linux to FreeBSD
  * `linux-64-x-armsf` - tests cross compiling from x86_64 linux to arm-*-*-gnueabi (soft float) linux
  * `linux-64-x-armhf` - tests cross compiling form x86_64 linux to arm-*-*-gnueabihf (hard float) linux
* One new dist builder is created:
  * `cross-host-linux` - produces host compilers

The goal of this PR is to prep both our gated commits as well as our nightlies
for producing NetBSD, FreeBSD, ARM, ARMv7, and ARM (hard float) compilers. Some
tinings of this were tested in dev with respect to the time it takes for an auto
builder to compile the number of *extra* hosts. In the table below one column
is bootstrapping plus compiling LLVM (a cold cache) and another is just the
bootstrap where we didn't have to recompile LLVM (a warm cache)


| Extra hosts | boostrap + LLVM |   boostrap   |
|-------------|-----------------|--------------|
|     2       |   3hrs 4min     |  2hrs 7min   |
|     3       |   4hrs 24min    |  2hrs 55min  |
|     5       |   6hrs 56min    |     N/A      |

Note that there was some contention on the machines so that's why the drops
aren't exactly as one might expect. In any case it looks like we shouldn't
bootstrap more than *one* extra host on an auto builder to keep build times
reasonable. As a result, each of the `-x-` builders added only crosses to one
extra host, and a builder wasn't added for ARMv7 as it should be the same as ARM
hard float.

Hopefully once this lands and we update the builders, we'll just magically get a
whole lot more compilers overnight!
