### PR TITLE
Add i586-* builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -147,6 +147,7 @@ auto_platforms = [
     "win-msvc-32-opt",
     "win-msvc-64-opt",
     "win-msvc-64-opt-mir",
+    "win-msvc-32-cross-opt",
 
     "win-gnu-32-opt-rustbuild",
     "win-msvc-64-opt-rustbuild",
@@ -168,7 +169,8 @@ dist_platforms = ["linux", "mac", "arm-android", "musl-linux",
                   "cross-host-linux",
                   "mac-ios",
                   "win-gnu-32", "win-gnu-64",
-                  "win-msvc-32", "win-msvc-64"]
+                  "win-msvc-32", "win-msvc-64",
+                  "win-msvc-32-cross"]
 packaging_platforms = ["linux", "mac",
                        "win-gnu-32", "win-gnu-64",
                        "win-msvc-32", "win-msvc-64"]
@@ -204,6 +206,7 @@ nogate_builders = [
 dist_nogate_platforms = [
     "mac-ios",
     "cross-host-linux",
+    "cross-win",
 ]
 
 cross_host_targets = [
@@ -225,6 +228,7 @@ cargo_cross_targets = [
 nightly_lincross_targets = [
   'mips-unknown-linux-musl',
   'mipsel-unknown-linux-musl',
+  'i586-unknown-linux-gnu',
 ]
 beta_lincross_targets = [
   'armv7-unknown-linux-gnueabihf',
@@ -240,6 +244,11 @@ stable_lincross_targets = [
   'mipsel-unknown-linux-gnu',
   'aarch64-unknown-linux-gnu',
 ]
+nightly_wincross_targets = [
+  'i586-pc-windows-msvc',
+]
+beta_wincross_targets = []
+stable_wincross_targets = []
 
 ios_targets = [
   'aarch64-apple-ios',
@@ -251,6 +260,8 @@ ios_targets = [
 
 all_lincross_targets = nightly_lincross_targets + beta_lincross_targets + \
   stable_lincross_targets
+all_wincross_targets = nightly_wincross_targets + beta_wincross_targets + \
+  stable_wincross_targets
 
 ####### BUILDSLAVES
 
@@ -1593,7 +1604,7 @@ def platform_snap_slaves(p):
 # FIXME: The linux AMI instances are using valgrind 3.7 and we need 3.8+
 # This rule limits which bots we run the valgrinding dist snapshot on.
 def platform_dist_slaves(p):
-    if 'musl' in p or 'cross' in p or 'ios' in p:
+    if 'musl' in p or 'cross-linux' in p or 'ios' in p:
         return platform_slaves(p)
 
     # p is exactly the platform name, ie arm-android
@@ -1664,6 +1675,9 @@ for p in auto_platforms:
     if "linux-cross" in p:
         chk = False
         targets += all_lincross_targets
+    if "win-msvc-32-cross" in p:
+        chk = False
+        targets += all_wincross_targets
     if "ios" in p:
         chk = False
         targets += ios_targets
@@ -1757,16 +1771,23 @@ for p in dist_platforms:
         rustbuild = None
 
         my_lincross_targets = []
+        my_wincross_targets = []
         my_cross_host_targets = []
         if channel == 'stable':
             my_lincross_targets += stable_lincross_targets
+            my_wincross_targets += stable_wincross_targets
         if channel == 'beta':
             my_lincross_targets += stable_lincross_targets
             my_lincross_targets += beta_lincross_targets
+            my_wincross_targets += stable_wincross_targets
+            my_wincross_targets += beta_wincross_targets
         elif channel == 'nightly':
             my_lincross_targets += stable_lincross_targets
             my_lincross_targets += beta_lincross_targets
             my_lincross_targets += nightly_lincross_targets
+            my_wincross_targets += stable_wincross_targets
+            my_wincross_targets += beta_wincross_targets
+            my_wincross_targets += nightly_wincross_targets
             my_cross_host_targets += [h['target'] for h in cross_host_targets]
 
         # The `cross-linux` builder below is intended for just producing
@@ -1785,6 +1806,8 @@ for p in dist_platforms:
 
         if "cross-linux" in p:
             my_targets += my_lincross_targets
+        if "win-msvc-32-cross" in p:
+            my_targets += my_wincross_targets
         if "cross-host-linux" in p:
             rustbuild = True
             my_hosts = my_cross_host_targets


### PR DESCRIPTION
This adds i586-unknown-linux-gnu to the list of cross-std builders as well as
adds a whole new set of windows builders for producing the i586-pc-windows-msvc
cross-std.