### PR TITLE
slaves/linux: install newer cmake

### DIFF
--- a/slaves/linux/Dockerfile
+++ b/slaves/linux/Dockerfile
@@ -3,10 +3,16 @@ FROM ubuntu:14.04
 RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y \
-        curl make cmake xz-utils git \
+        curl make xz-utils git \
         python-dev python-pip stunnel \
         g++-multilib libssl-dev libssl-dev:i386 gdb \
-        valgrind libc6-dbg:i386
+        valgrind libc6-dbg:i386 software-properties-common
+
+# for cargo, we need cmake-3.1.2+ to avoid a cmake bug where it doesn't detect
+# OpenSSL-1.0.2.
+# See https://cmake.org/Bug/bug_relationship_graph.php?bug_id=15386
+RUN add-apt-repository ppa:george-edison55/cmake-3.x && apt-get update
+RUN apt-get install -y cmake
 
 # Install buildbot and prep it to run
 RUN pip install buildbot-slave


### PR DESCRIPTION
required to build cargo on this image

follow-up of rust-lang/cargo#2532

r? @alexcrichton 

I didn't add /musl-x86_64/bin to PATH in the Dockerfile. I think it would be better to do that in Cargo's configure script because this image is going to be used to cross compile std to x86_64-musl and i686-musl where both tasks also use `musl-gcc` so we may accidentally end up using `/musl-x86_64/bin/musl-gcc` when building std for i686-musl. Also if we ever build cargo for i686-musl, we'll probably end up using Cargo's configure script to pick the right `musl-gcc` anyways.