### PR TITLE
Build combined installers for cross hosts

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1517,7 +1517,19 @@ def packaging_dist_buildfactory(platform, channel_label):
                            command=["rm", "-Rf", "in", "out", "tmp"],
                            haltOnFailure=True))
 
-    for target in all_platform_hosts(platform):
+    hosts = all_platform_hosts(platform)
+    if platform == 'linux':
+        if channel_label == 'stable':
+            hosts += [h['target'] for h in stable_cross_host_targets]
+        elif channel_label == 'beta':
+            hosts += [h['target'] for h in stable_cross_host_targets]
+            hosts += [h['target'] for h in beta_cross_host_targets]
+        else:
+            hosts += [h['target'] for h in stable_cross_host_targets]
+            hosts += [h['target'] for h in beta_cross_host_targets]
+            hosts += [h['target'] for h in nightly_cross_host_targets]
+
+    for target in hosts:
 
         f.addStep(Compile(env=CommandEnv(),
                           name="fetch inputs",


### PR DESCRIPTION
We've got the docs, cargo, and rustc packages all up and running, so let's start
packing these up so rustup can pick them up as well.