### PR TITLE
android version downgrade for arm and x86

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -864,7 +864,7 @@ class ConfigCommand(object):
 
         # Set up the path to the android NDK
         if testing_android:
-            s += " --arm-linux-androideabi-ndk=/android/ndk-arm-18"
+            s += " --arm-linux-androideabi-ndk=/android/ndk-arm-9"
             s += " --i686-linux-android-ndk=/android/ndk-x86"
             s += " --aarch64-linux-android-ndk=/android/ndk-aarch64"
             s += " --disable-docs"

--- a/slaves/android/install-ndk.sh
+++ b/slaves/android/install-ndk.sh
@@ -13,6 +13,9 @@ bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
         --install-dir=/android/ndk-arm-9 \
         --ndk-dir=/android/android-ndk-r11c \
         --arch=arm
+# NB: this arm toolchain is used for testing the libc crate to ensure it
+# works against the most recent version of android.  It cannot be combined
+# with the previous toolchain!
 bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
         --platform=android-21 \
         --toolchain=arm-linux-androideabi-4.9 \


### PR DESCRIPTION
Compiling Rust's `std` works just fine with API level 9.  I didn't see anything too unusual in Rust's system-dependent code when I looked for possible gotchas, but I also didn't test this beyond compiling things.

Two interesting things to note that I discovered this morning:

1. Firefox is currently in the middle of changing its API level requirements.  Nightly Firefox only supports ICS (API level 15); I'm unsure of where Beta and Developer Edition are with regards to the API level change.  I'd like Rust stable to be usable with both `arm-linux-androideabi` and `i686-linux-android` sooner rather than later, though, and lowering the requirements as far as possible seems like a good thing in any event.
2. Servo's wiki [instructions for building for Android](https://github.com/servo/servo/wiki/Building-for-Android) state that you should use API level 18, which I presume is why 18 was chosen for the buildbot configs.  But I don't think this should hold back moving the Rust requirements backwards; compiling Servo with API level 18 using a Rust `std` compiled against API level 9 ought to work just fine.

This pull request also sneaks in what looks like a cleanup: making sure we only have one ARM standalone toolchain built from the NDK.  It's entirely possible there are constraints here that I'm not aware of (extra tools?  multilibs?), so please do tell me if that commit is bogus, and I'll happily drop it.