### PR TITLE
update Android builds to use NDK r11c

### DIFF
--- a/slaves/android/install-ndk.sh
+++ b/slaves/android/install-ndk.sh
@@ -5,38 +5,37 @@ set -ex
 # Prep the Android NDK
 #
 # See https://github.com/servo/servo/wiki/Building-for-Android
-curl -O http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin
-chmod +x android-ndk-r10e-linux-x86_64.bin
-./android-ndk-r10e-linux-x86_64.bin > /dev/null
-bash android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
+curl -O http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip
+unzip -q android-ndk-r11c-linux-x86_64.zip
+bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
         --platform=android-18 \
-        --toolchain=arm-linux-androideabi-4.8 \
+        --toolchain=arm-linux-androideabi-4.9 \
         --install-dir=/android/ndk-arm-18 \
-        --ndk-dir=/android/android-ndk-r10e \
+        --ndk-dir=/android/android-ndk-r11c \
         --arch=arm
-bash android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
+bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
         --platform=android-21 \
-        --toolchain=arm-linux-androideabi-4.8 \
+        --toolchain=arm-linux-androideabi-4.9 \
         --install-dir=/android/ndk-arm \
-        --ndk-dir=/android/android-ndk-r10e \
+        --ndk-dir=/android/android-ndk-r11c \
         --arch=arm
-bash android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
+bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
         --platform=android-21 \
         --toolchain=aarch64-linux-android-4.9 \
         --install-dir=/android/ndk-aarch64 \
-        --ndk-dir=/android/android-ndk-r10e \
+        --ndk-dir=/android/android-ndk-r11c \
         --arch=arm64
-bash android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
+bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
         --platform=android-21 \
         --toolchain=x86-4.9 \
         --install-dir=/android/ndk-x86 \
-        --ndk-dir=/android/android-ndk-r10e \
+        --ndk-dir=/android/android-ndk-r11c \
         --arch=x86
-bash android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
+bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
         --platform=android-21 \
         --toolchain=x86_64-4.9 \
         --install-dir=/android/ndk-x86_64 \
-        --ndk-dir=/android/android-ndk-r10e \
+        --ndk-dir=/android/android-ndk-r11c \
         --arch=x86_64
 
-rm -rf ./android-ndk-r10e-linux-x86_64.bin ./android-ndk-r10e
+rm -rf ./android-ndk-r11c-linux-x86_64.zip ./android-ndk-r11c


### PR DESCRIPTION
One of the changes in Android NDK r11 and above is:

  Removed from all versions of NDK libc, m, and dl all symbols which the
  platform versions of those libs do not support.

This cryptic statement means that a number of symbols that the header
files no longer use were removed from libc and friends.  What this means
in practice is that the Rust libraries for arm-linux-androideabi contain
references to symbols that no longer exist in current versions of the
NDK.  Which means that you have to use the exact version of the NDK (or
previous versions, presumably) that Rust was built with to use the
prebuilt binaries, but you can't use any later versions.

This situation seems undesirable.  To alleviate this, this patch moves
to using version r11c of the NDK, which ought to be just as
backwards-compatible, as well as (more) forwards-compatible.  Moving to
r11c requires that the arm-linux-androideabi target now use GCC 4.9, but
that should not be a problem, as other Android architectures Rust builds
for were already using GCC 4.9.