### PR TITLE
Include source packages in manifest

### DIFF
--- a/master/build-rust-manifest.py
+++ b/master/build-rust-manifest.py
@@ -415,8 +415,8 @@ def live_package_url(name, dist_dir, date, version, target):
     if name == "rust-src":
         # The build system treats source packages as a separate target for `rustc`
         # but for rustup we'd like to treat them as a completely separate package.
-        url1 = s3_addy + "/" + dist_dir + "/" + date + "/rustc-" + version + "-src.tar.gz"
-        url2 = s3_addy + "/" + dist_dir + "/" + date + "/rustc-" + maybe_channel + "-src.tar.gz"
+        url1 = s3_addy + "/" + dist_dir + "/" + date + "/rust-src-" + version + ".tar.gz"
+        url2 = s3_addy + "/" + dist_dir + "/" + date + "/rust-src-" + maybe_channel + ".tar.gz"
     else:
         url1 = s3_addy + "/" + dist_dir + "/" + date + "/" + name + "-" + version + "-" + target + ".tar.gz"
         url2 = s3_addy + "/" + dist_dir + "/" + date + "/" + name + "-" + maybe_channel + "-" + target + ".tar.gz"

--- a/master/build-rust-manifest.py
+++ b/master/build-rust-manifest.py
@@ -481,39 +481,48 @@ def url_and_hash_of_rust_package(target, rustc_short_version):
     }
 
 def write_manifest(manifest, file_path):
+    def quote(value):
+        return '"' + str(value).replace('"', r'\"') + '"'
+    
+    def bare_key(key):
+        if re.match(r"^[a-zA-Z0-9_\-]+$", key):
+            return key
+        else:
+            return quote(key)
+
     with open(file_path, "w") as f:
         f.write('manifest-version = "2"\n')
-        f.write('date = "' + today + '"\n')
+        f.write('date = ' + quote(today) + '\n')
         f.write('\n')
 
         for name, pkg in sorted(manifest["pkg"].items()):
-            f.write('[pkg.' + name + ']\n')
-            f.write('version = "' + pkg["version"] + '"\n')
+            f.write('[pkg.' + bare_key(name) + ']\n')
+            f.write('version = ' + quote(pkg["version"]) + '\n')
             f.write('\n')
 
             for target, target_pkg in sorted(pkg["target"].items()):
                 available = "true"
                 if not target_pkg["available"]: available = "false"
 
-                f.write('[pkg.' + name + '.target.' + target + ']\n')
+                f.write('[pkg.' + bare_key(name) + '.target.' + bare_key(target) + ']\n')
                 f.write('available = ' + available + '\n')
-                f.write('url = "' + target_pkg["url"] + '"\n')
-                f.write('hash = "' + target_pkg["hash"] + '"\n')
+                f.write('url = ' + quote(target_pkg["url"]) + '\n')
+                f.write('hash = ' + quote(target_pkg["hash"]) + '\n')
                 f.write('\n')
 
                 components = target_pkg.get("components")
                 if components:
                     for component in components:
-                        f.write('[[pkg.' + name + '.target.' + target + '.components]]\n')
-                        f.write('pkg = "' + component["pkg"] + '"\n')
-                        f.write('target = "' + component["target"] + '"\n')
+                        f.write('[[pkg.' + bare_key(name) + '.target.' + bare_key(target) + '.components]]\n')
+                        f.write('pkg = ' + quote(component["pkg"]) + '\n')
+                        f.write('target = ' + quote(component["target"]) + '\n')
 
                 extensions = target_pkg.get("extensions")
                 if extensions:
                     for extension in extensions:
-                        f.write('[[pkg.' + name + '.target.' + target + '.extensions]]\n')
-                        f.write('pkg = "' + extension["pkg"] + '"\n')
-                        f.write('target = "' + extension["target"] + '"\n')
+                        f.write('[[pkg.' + bare_key(name) + '.target.' + bare_key(target) + '.extensions]]\n')
+                        f.write('pkg = ' + quote(extension["pkg"]) + '\n')
+                        f.write('target = ' + quote(extension["target"]) + '\n')
 
                 f.write('\n')
 


### PR DESCRIPTION
This will allow rustup to install the rust source as an optional extension for a given toolchain.