### PR TITLE
Build and release aarch64 android binaries.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1715,6 +1715,7 @@ for p in auto_platforms:
     if "-x-android" in p:
         targets.append('arm-linux-androideabi')
         targets.append('i686-linux-android')
+        targets.append('aarch64-linux-android')
         android = True
         # Not checking android for now
         chk = False
@@ -1773,6 +1774,7 @@ for p in dist_platforms:
         hosts = []
         targets.append('arm-linux-androideabi')
         targets.append('i686-linux-android')
+        targets.append('aarch64-linux-android')
     elif "musl" in p:
         musl = "/musl-x86_64"
         hosts = []


### PR DESCRIPTION
Adding Android Aarch64 to the buildbots was discussed on https://internals.rust-lang.org/t/suggestion-make-real-world-tier-1-platforms-at-least-tier-2/3492

Also e5ac28a54973ea7c07f55048c2038354108ad730 has the commit log "Build and release i686+aarch64 android binaries" but it doesn't add Aarch64.