### PR TITLE
Openssl 1.0.2h

### DIFF
--- a/slaves/dist/Dockerfile
+++ b/slaves/dist/Dockerfile
@@ -2,6 +2,9 @@ FROM centos:5
 
 WORKDIR /build
 
+# Install updates.
+RUN yum upgrade -y
+
 # curl == now we can download things
 # bzip2 == now we can download bz2 things
 # gcc == now we can build gcc

--- a/slaves/dist/build_curl.sh
+++ b/slaves/dist/build_curl.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=7.47.1
-SHA256=ddc643ab9382e24bbe4747d43df189a0a6ce38fcb33df041b9cb0b3cd47ae98f
+VERSION=7.49.0
+SHA256=14f44ed7b5207fea769ddb2c31bd9e720d37312e1c02315def67923a4a636078
 
 curl http://cool.haxx.se/download/curl-$VERSION.tar.bz2 | \
   tee >(sha256sum > curl-$VERSION.tar.bz2.sha256)       | tar xjf -

--- a/slaves/dist/build_git.sh
+++ b/slaves/dist/build_git.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=2.7.4
-SHA256=7104c4f5d948a75b499a954524cb281fe30c6649d8abe20982936f75ec1f275b
+VERSION=2.8.3
+SHA256=2dad50c758339d6f5235309db620e51249e0000ff34aa2f2acbcb84c2123ed09
 
 yum install -y gettext autoconf
 curl https://www.kernel.org/pub/software/scm/git/git-$VERSION.tar.gz | \

--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -2,11 +2,11 @@
 
 set -ex
 
-VERSION=1.0.2g
-SHA256=b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
+VERSION=1.0.2h
+SHA256=1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
 
 yum install -y setarch
-curl http://openssl.org/source/openssl-$VERSION.tar.gz | \
+curl ftp://ftp.openssl.org/source/openssl-$VERSION.tar.gz | \
   tee >(sha256sum > openssl-$VERSION.tar.gz.sha256)    | tar xzf -
 test $SHA256 = $(cut -d ' ' -f 1 openssl-$VERSION.tar.gz.sha256) || exit 1
 


### PR DESCRIPTION
A couple of updates to the buildbot base. The critical openssl update doesn't affect us (privacy-impact only) but there are a couple of overflow fixes which could. The git and curl bumps are just updating to the latest.

I expect we'll want to wait until after tomorrow's merge day to deploy these, but I did the bump on my gecko-side builder.

r? @edunham 
