### PR TITLE
Reduce the number of auto builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -112,7 +112,7 @@ auto_platforms = [
     #"mac-32-nopt-t",
     "mac-64-opt",
     #"mac-64-nopt-c",
-    "mac-64-nopt-t",
+    #"mac-64-nopt-t",
     #"mac-64-opt-vg",
     #"mac-all-opt",
     "mac-cross-ios-opt",
@@ -127,7 +127,7 @@ auto_platforms = [
     "linux-64-debug-opt",
     "linux-musl-64-opt",
     "linux-cross-opt",
-    "linux-32cross-opt",
+    #"linux-32cross-opt",
     "linux-64-opt-rustbuild",
     "linux-64-opt-mir",
 
@@ -135,21 +135,21 @@ auto_platforms = [
     #"linux-all-opt",
 
     "linux-64-x-android-t",
-    "linux-64-cross-netbsd",
+    #"linux-64-cross-netbsd",
     "linux-64-cross-freebsd",
-    "linux-64-cross-armsf",
-    "linux-64-cross-armhf",
+    #"linux-64-cross-armsf",
+    #"linux-64-cross-armhf",
 
     "win-gnu-32-opt",
     #"win-gnu-32-nopt-c",
-    "win-gnu-32-nopt-t",
+    #"win-gnu-32-nopt-t",
     "win-gnu-64-opt",
     #"win-gnu-64-nopt-c",
-    "win-gnu-64-nopt-t",
+    #"win-gnu-64-nopt-t",
     "win-msvc-32-opt",
     "win-msvc-64-opt",
     "win-msvc-64-opt-mir",
-    "win-msvc-32-cross-opt",
+    #"win-msvc-32-cross-opt",
 
     "win-gnu-32-opt-rustbuild",
     "win-msvc-64-opt-rustbuild",
@@ -159,17 +159,19 @@ auto_platforms = [
     "win-msvc-64-cargotest",
 
     # Tier 2 platforms, also modify nogate_builders
-    "bitrig-64-opt",
-    "freebsd10_32-1",
-    "freebsd10_64-1",
-    "dragonflybsd-64-opt",
-    "openbsd-64-opt"
+    #"bitrig-64-opt",
+    #"freebsd10_32-1",
+    #"freebsd10_64-1",
+    #"dragonflybsd-64-opt",
+    #"openbsd-64-opt"
 ]
 
 try_platforms = ["linux", "win-gnu-32", "win-gnu-64", "mac"]
-snap_platforms = ["linux", "win-gnu-32", "win-gnu-64", "mac", "bitrig-64",
-                  "freebsd10_32-1", "freebsd10_64-1", "dragonflybsd-64-opt",
-                  "openbsd-64-opt"]
+snap_platforms = ["linux", "win-gnu-32", "win-gnu-64", "mac",
+                  #"bitrig-64",
+                  #"freebsd10_32-1", "freebsd10_64-1", "dragonflybsd-64-opt",
+                  #"openbsd-64-opt"
+                  ]
 dist_platforms = ["linux", "mac", "arm-android", "musl-linux",
                   "cross-linux",
                   "cross32-linux",
@@ -185,7 +187,8 @@ cargo_platforms = ["linux-32", "linux-64", "mac-32", "mac-64",
                    "cross-linux",
                    "win-gnu-32", "win-gnu-64",
                    "win-msvc-32", "win-msvc-64",
-                   "bitrig-64"]
+                   #"bitrig-64"
+                   ]
 cargo_dist_platforms = [p for p in cargo_platforms if "linux" in p or "mac" in p or "win" in p]
 
 def works_in_dev(platform):


### PR DESCRIPTION
* mac-64-nopt-t - do nopt-t on Linux
* linux-32cross-opt - rarely turns up regressions and we have nightlies
* linux-64-cross-netbsd - rarely turns up regressions and we have nightlies
* linux-64-cross-armsf - rarely turns up regressions and we have nightlies
* linux-64-cross-armhf - rarely turns up regressions and we have nightlies
* win-gnu-32-nopt-t - do nopt-t on Linux
* win-gnu-64-nopt-t - do nopt-t on Linux
* win-msvc-32-cross-opt - rarely turns up regressions and we have nightlies
* bitrig/freebsd/dragonfly/openbsd - bots haven't been online in awhile