### PR TITLE
turn off newer RELX relocation optimizations

### DIFF
--- a/slaves/linux/build-musl.sh
+++ b/slaves/linux/build-musl.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export CFLAGS=-fPIC
+export CFLAGS=-fPIC -Wa,-mrelax-relocations=no
 MUSL=musl-1.1.14
 # Support building MUSL
 curl http://www.musl-libc.org/releases/$MUSL.tar.gz | tar xzf -


### PR DESCRIPTION
otherwise breaks the link step on systems with an older linker (i.e., travis CI, some ubuntu's, etc.). ref rust-lang/rust#34978

We may only want to add this flag on nightly? Not sure how to do that...

*NB* requires a newer assembler (don't know exact minimal working version), but
```
as -version
GNU assembler (GNU Binutils) 2.26.0.20160501
```
works.