### PR TITLE
add CXXFLAGS for cmake

### DIFF
--- a/slaves/linux/build-musl.sh
+++ b/slaves/linux/build-musl.sh
@@ -3,6 +3,7 @@
 set -ex
 
 export CFLAGS="-fPIC -Wa,-mrelax-relocations=no"
+export CXXFLAGS="-Wa,-mrelax-relocations=no"
 MUSL=musl-1.1.14
 # Support building MUSL
 curl http://www.musl-libc.org/releases/$MUSL.tar.gz | tar xzf -


### PR DESCRIPTION
Because it doesn't seem to respect CFLAGS, and we still have RELX relocations in `libunwind.a` :(

ref rust-lang/rust/issues/34978