### PR TITLE
Investigate debug-opt timeouts.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -81,7 +81,7 @@ security_name = None
 # to prevent slaves from needing to be restarted while bors's queue is full
 build_wait_timeout = (60*60)*3
 dist_wait_timeout = 10 * 60 # dist bots don't need to stay online
-compile_timeout = 30*60 # rustc can take a while to compile
+compile_timeout = 60*60 # rustc can take a while to compile
 test_timeout = 20*60
 region = 'us-west-1'
 
@@ -1061,7 +1061,7 @@ def just_tidy_buildfactory():
                       command=[MakeCommand(), "tidy"]))
     return f
 
-def make_and_check_buildfactory(check, android, windows, parallel):
+def make_and_check_buildfactory(check, android, windows, parallel, make_args=[]):
     checking_android = android == True and check != False
     f = checkout_and_configure_buildfactory(checking_android)
     # Temporary until we convince the build system
@@ -1087,6 +1087,7 @@ def make_and_check_buildfactory(check, android, windows, parallel):
         command = [MakeCommand()]
     else:
         command = [MakeCommand(), "-j2"]
+    command += mk_args
     f.addStep(Compile(env=CommandEnv(),
                       haltOnFailure=True,
                       flunkOnFailure=True,
@@ -1674,10 +1675,12 @@ for p in auto_platforms:
     chk = True
     rustbuild = None
     orbit = None
+    make_args = []
 
     if "-debug" in p:
         debug = True
         chk = False
+        make_args.append("RUSTFLAGS_STAGE2=-Ztime-passes")
 
     if "-nopt-c" in p:
         opt_compiler = False
@@ -1756,7 +1759,8 @@ for p in auto_platforms:
                         "orbit": orbit,
                         "rustbuild": rustbuild},
             factory=make_and_check_buildfactory(chk, android,
-                                                "win" in p, True)))
+                                                "win" in p, True,
+                                                make_args)))
 
 for p in snap_platforms:
     c['builders'].append(BuilderConfig(


### PR DESCRIPTION
Lacking a local reproduction of rust-lang/rust#35628, this PR both doubles the timeout limit and forces debug builds to print out their pass timings for stage2 - we can then at least see where it goes wrong.

r? @alexcrichton