### PR TITLE
prepare for rustc for mips-gnu, mipsel-gnu, ppc64-gnu and ppc64el-gnu

### DIFF
--- a/slaves/linux-cross/Dockerfile
+++ b/slaves/linux-cross/Dockerfile
@@ -7,8 +7,9 @@ RUN apt-get install -y --force-yes --no-install-recommends \
         bzip2 xz-utils \
         g++ libc6-dev \
         g++-4.8-powerpc-linux-gnu libc6-dev-powerpc-cross \
+        g++-5-powerpc64-linux-gnu libc6-dev-ppc64-powerpc-cross \
         g++-4.8-powerpc64le-linux-gnu libc6-dev-ppc64el-cross \
-        lib64gcc-4.8-dev-powerpc-cross libc6-dev-ppc64-powerpc-cross \
+        lib64gcc-4.8-dev-powerpc-cross \
         lib64stdc++-4.8-dev-powerpc-cross \
         bsdtar \
         cmake \
@@ -165,12 +166,24 @@ ENV AR_armv7_unknown_linux_gnueabihf=armv7-linux-gnueabihf-ar \
     AR_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-ar \
     CC_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-gcc \
     CXX_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-g++ \
+    AR_mips_unknown_linux_gnu=mips-linux-gnu-ar \
+    CC_mips_unknown_linux_gnu=mips-linux-gnu-gcc-5 \
+    CXX_mips_unknown_linux_gnu=mips-linux-gnu-g++-5 \
     AR_mips_unknown_linux_musl=mips-linux-musl-ar \
     CC_mips_unknown_linux_musl=mips-linux-musl-gcc \
     CXX_mips_unknown_linux_musl=mips-linux-musl-g++ \
+    AR_mipsel_unknown_linux_gnu=mipsel-linux-gnu-ar \
+    CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc-5 \
+    CXX_mipsel_unknown_linux_gnu=mipsel-linux-gnu-g++-5 \
     AR_mipsel_unknown_linux_musl=mipsel-linux-musl-ar \
     CC_mipsel_unknown_linux_musl=mipsel-linux-musl-gcc \
-    CXX_mipsel_unknown_linux_musl=mipsel-linux-musl-g++
+    CXX_mipsel_unknown_linux_musl=mipsel-linux-musl-g++ \
+    AR_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-ar \
+    CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc-5 \
+    CXX_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-g++-5 \
+    AR_powerpc64le_unknown_linux_gnu=powerpc64-linux-gnu-ar \
+    CC_powerpc64le_unknown_linux_gnu=powerpc64-linux-gnu-gcc-5 \
+    CXX_powerpc64le_unknown_linux_gnu=powerpc64-linux-gnu-g++-5
 
 # When running this container, startup buildbot
 WORKDIR /buildslave


### PR DESCRIPTION
Just (\*) by setting these env vars I could can use this command:

```
$ configure --enable-llvm-static-stdcpp --enable-rustbuild --host=mips-unknown-linux-gnu
$ make
```

to build rustc for these targets.

(\*) for ppc64, I additionally installed g++ for ppc64 because I didn't want to mess with CFLAGS
(i.e. `-m64`).

I tested building rustc for each target. Then tested, under QEMU, that each (\*\*) cross compiled
rustc could, itself, compile the "smallest hello" program (see code below). And, finally, I executed the smallest hello binary that was "natively" (under QEMU, withouth `--target` flag) compiled by the foregin `rustc`.

The commands looked like this:

```
$ uname -a
Linux 7d6aa2c97ca4 4.6.4 #1 SMP Fri Jul 22 11:55:10 PET 2016 x86_64 x86_64 x86_64 GNU/Linux

$ export QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu

# Note: transparent QEMU emulation via the qemu-user-static and binfmt-support packages
$ rustc -Vv
rustc 1.13.0-dev (eaf71f8d1 2016-08-25)
binary: rustc
commit-hash: eaf71f8d1034f16140791f566cab3f3c9a0bf96a
commit-date: 2016-08-25
host: powerpc64-unknown-linux-gnu
release: 1.13.0-dev

$ rustc -C linker=powerpc64-linux-gnu-gcc-5 smallest-hello.rs

$ file smallest-hello
puts: ELF 64-bit MSB shared object, 64-bit PowerPC or cisco 7500, version 1 (SYSV), dynamically linked, interpreter /lib64/ld64.so.1, for GNU/Linux 3.2.0, BuildID[sha1]=600eca53c0d784de9e680bc9e52a0e84af25acb9, not stripped

$ ./smallest-hello
Hello, world!
```

``` rust
// smallest-hello.rs
#![feature(start)]
#![feature(lang_items)]
#![feature(no_core)]
#![no_core]

#[link(name = "c")]
extern {
    fn puts(_: *const u8);
}

#[start]
fn start(_: isize, _: *const *const u8) -> isize {
    unsafe {
        let msg = b"Hello, world!\0";
        puts(msg as *const _ as *const u8);
    }
    0
}


#[lang = "copy"]
trait Copy {}

#[lang = "sized"]
trait Sized {}
```

(\*\*) I couldn't test the ppc64el target because qemu-ppc64el segfaulted with every binary I threw at
it (I even tried this C program: `int main() { return 0; }`). But rustc did successfully cross compile for that target.

r? @alexcrichton 