### PR TITLE
cross/arm: bump glibc to 2.16

### DIFF
--- a/slaves/linux-cross/arm-linux-gnueabi.config
+++ b/slaves/linux-cross/arm-linux-gnueabi.config
@@ -155,12 +155,6 @@ CT_ARCH_EXCLUSIVE_WITH_CPU=y
 # CT_ARCH_FLOAT_AUTO is not set
 # CT_ARCH_FLOAT_SOFTFP is not set
 CT_ARCH_FLOAT="soft"
-# CT_ARCH_ALPHA_EV4 is not set
-# CT_ARCH_ALPHA_EV45 is not set
-# CT_ARCH_ALPHA_EV5 is not set
-# CT_ARCH_ALPHA_EV56 is not set
-# CT_ARCH_ALPHA_EV6 is not set
-# CT_ARCH_ALPHA_EV67 is not set
 
 #
 # arm other options
@@ -307,11 +301,9 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
 # C-library
 #
 CT_LIBC="glibc"
-CT_LIBC_VERSION="2.14.1"
+CT_LIBC_VERSION="2.16.0"
 CT_LIBC_glibc=y
 # CT_LIBC_musl is not set
-# CT_LIBC_newlib is not set
-# CT_LIBC_none is not set
 # CT_LIBC_uClibc is not set
 CT_LIBC_avr_libc_AVAILABLE=y
 CT_LIBC_glibc_AVAILABLE=y
@@ -323,9 +315,9 @@ CT_THREADS="nptl"
 # CT_LIBC_GLIBC_V_2_19 is not set
 # CT_LIBC_GLIBC_V_2_18 is not set
 # CT_LIBC_GLIBC_V_2_17 is not set
-# CT_LIBC_GLIBC_V_2_16_0 is not set
+CT_LIBC_GLIBC_V_2_16_0=y
 # CT_LIBC_GLIBC_V_2_15 is not set
-CT_LIBC_GLIBC_V_2_14_1=y
+# CT_LIBC_GLIBC_V_2_14_1 is not set
 # CT_LIBC_GLIBC_V_2_14 is not set
 # CT_LIBC_GLIBC_V_2_13 is not set
 # CT_LIBC_GLIBC_V_2_12_2 is not set

--- a/slaves/linux-cross/arm-linux-gnueabihf.config
+++ b/slaves/linux-cross/arm-linux-gnueabihf.config
@@ -302,7 +302,7 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
 # C-library
 #
 CT_LIBC="glibc"
-CT_LIBC_VERSION="2.14.1"
+CT_LIBC_VERSION="2.16.0"
 CT_LIBC_glibc=y
 # CT_LIBC_musl is not set
 # CT_LIBC_uClibc is not set
@@ -316,9 +316,9 @@ CT_THREADS="nptl"
 # CT_LIBC_GLIBC_V_2_19 is not set
 # CT_LIBC_GLIBC_V_2_18 is not set
 # CT_LIBC_GLIBC_V_2_17 is not set
-# CT_LIBC_GLIBC_V_2_16_0 is not set
+CT_LIBC_GLIBC_V_2_16_0=y
 # CT_LIBC_GLIBC_V_2_15 is not set
-CT_LIBC_GLIBC_V_2_14_1=y
+# CT_LIBC_GLIBC_V_2_14_1 is not set
 # CT_LIBC_GLIBC_V_2_14 is not set
 # CT_LIBC_GLIBC_V_2_13 is not set
 # CT_LIBC_GLIBC_V_2_12_2 is not set

--- a/slaves/linux-cross/armv7-linux-gnueabihf.config
+++ b/slaves/linux-cross/armv7-linux-gnueabihf.config
@@ -3,7 +3,6 @@
 # Crosstool-NG Configuration
 #
 CT_CONFIGURE_has_make381=y
-CT_CONFIGURE_has_xz=y
 CT_MODULES=y
 
 #
@@ -156,6 +155,12 @@ CT_ARCH_EXCLUSIVE_WITH_CPU=y
 # CT_ARCH_FLOAT_AUTO is not set
 # CT_ARCH_FLOAT_SOFTFP is not set
 CT_ARCH_FLOAT="hard"
+# CT_ARCH_ALPHA_EV4 is not set
+# CT_ARCH_ALPHA_EV45 is not set
+# CT_ARCH_ALPHA_EV5 is not set
+# CT_ARCH_ALPHA_EV56 is not set
+# CT_ARCH_ALPHA_EV6 is not set
+# CT_ARCH_ALPHA_EV67 is not set
 
 #
 # arm other options
@@ -303,9 +308,11 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
 # C-library
 #
 CT_LIBC="glibc"
-CT_LIBC_VERSION="2.14.1"
+CT_LIBC_VERSION="2.16.0"
 CT_LIBC_glibc=y
 # CT_LIBC_musl is not set
+# CT_LIBC_newlib is not set
+# CT_LIBC_none is not set
 # CT_LIBC_uClibc is not set
 CT_LIBC_avr_libc_AVAILABLE=y
 CT_LIBC_glibc_AVAILABLE=y
@@ -317,9 +324,9 @@ CT_THREADS="nptl"
 # CT_LIBC_GLIBC_V_2_19 is not set
 # CT_LIBC_GLIBC_V_2_18 is not set
 # CT_LIBC_GLIBC_V_2_17 is not set
-# CT_LIBC_GLIBC_V_2_16_0 is not set
+CT_LIBC_GLIBC_V_2_16_0=y
 # CT_LIBC_GLIBC_V_2_15 is not set
-CT_LIBC_GLIBC_V_2_14_1=y
+# CT_LIBC_GLIBC_V_2_14_1 is not set
 # CT_LIBC_GLIBC_V_2_14 is not set
 # CT_LIBC_GLIBC_V_2_13 is not set
 # CT_LIBC_GLIBC_V_2_12_2 is not set


### PR DESCRIPTION
binaries built using the glibc-2.14 based toolchain segfaulted vhen
executed on ARM hardware (see issue linked below) due to a glibc bug.
Bumping the glibc version fixes the issue.

fixes rust-lang/rust#35843

r? @alexcrichton 

I've tested that the glibc-2.16 based toolchain produces good binaries for the armv7 target. I also tried to build a glibc-2.15 based toolchain but crosstool-ng failed to build/compile it.