### PR TITLE
openssl 1.0.2i

### DIFF
--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=1.0.2h
-SHA256=1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
+VERSION=1.0.2i
+SHA256=9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f
 
 yum install -y setarch
 curl ftp://ftp.openssl.org/source/openssl-$VERSION.tar.gz | \


### PR DESCRIPTION
New release addressing a number of security issues. At first glance, risk to our application is low (denial of service). Still important to upgrade of course. Issue list at https://www.openssl.org/news/secadv/20160922.txt

Also, the old source package has been taken down, so updating is necessary for our docker images to bootstrap.