### PR TITLE
Add emscripten targets to new 'rustbuildcross' slaves

### DIFF
--- a/master/build-rust-manifest.py
+++ b/master/build-rust-manifest.py
@@ -73,6 +73,7 @@ target_list = sorted([
     "aarch64-apple-ios",
     "aarch64-linux-android",
     "aarch64-unknown-linux-gnu",
+    "asmjs-unknown-emscripten",
     "arm-linux-androideabi",
     "arm-unknown-linux-gnueabi",
     "arm-unknown-linux-gnueabihf",
@@ -109,6 +110,7 @@ target_list = sorted([
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-unknown-netbsd",
+    "wasm32-unknown-emscripten",
 ])
 
 # windows-gnu platforms require an extra bundle of gnu stuff

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -127,6 +127,7 @@ auto_platforms = [
     "linux-64-debug-opt",
     "linux-musl-64-opt",
     "linux-cross-opt",
+    "linux-rustbuildcross-opt",
     #"linux-32cross-opt",
     "linux-64-opt-rustbuild",
 
@@ -174,6 +175,7 @@ dist_platforms = ["linux", "mac", "arm-android", "musl-linux",
                   "cross-linux",
                   "cross32-linux",
                   "cross-host-linux",
+                  "rustbuildcross-linux",
                   "mac-ios",
                   "win-gnu-32", "win-gnu-64",
                   "win-msvc-32", "win-msvc-64",
@@ -209,11 +211,13 @@ nogate_builders = [
     "auto-freebsd10_64-1",
     "auto-dragonflybsd-64-opt",
     "auto-openbsd-64-opt",
+    "auto-linux-rustbuildcross-opt",
 ]
 dist_nogate_platforms = [
     #"mac-ios",
     #"cross-host-linux",
     #"cross-win",
+    "rustbuildcross-linux",
 ]
 
 cargo_cross_targets = [
@@ -229,6 +233,7 @@ cargo_cross_targets = [
 ios = {'auto': 'cross-ios-opt', 'dist': 'mac-ios'}
 lincross = {'auto': 'linux-cross', 'dist': 'cross-linux'}
 lincross32 = {'auto': 'linux-32cross', 'dist': 'cross32-linux'}
+lincross_rustbuild = {'auto': 'linux-rustbuildcross', 'dist': 'rustbuildcross-linux'}
 msvc32 = {'auto': 'msvc-32-cross', 'dist': 'win-msvc-32-cross'}
 
 def xhost(name):
@@ -269,6 +274,8 @@ nightly_cross_targets = beta_cross_targets + [
   #{'t': 'arm-unknown-linux-musleabi', 'b': lincross},
   #{'t': 'arm-unknown-linux-musleabihf', 'b': lincross},
   #{'t': 'armv7-unknown-linux-musleabihf', 'b': lincross},
+  {'t': 'asmjs-unknown-emscripten', 'b': lincross_rustbuild},
+  {'t': 'wasm32-unknown-emscripten', 'b': lincross_rustbuild},
 ]
 
 ####### BUILDSLAVES


### PR DESCRIPTION
I'm still waiting for the nightly to finish in dev, but I think it will be successful.

I ended up doing this by adding new "rustbuildcross" slaves, which of course will take up more resources...