### PR TITLE
binutils 2.27

### DIFF
--- a/slaves/dist/build_binutils.sh
+++ b/slaves/dist/build_binutils.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=2.25.1
-SHA256=b5b14added7d78a8d1ca70b5cb75fef57ce2197264f4f5835326b0df22ac9f22
+VERSION=2.27
+SHA256=369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
 
 curl https://ftp.gnu.org/gnu/binutils/binutils-$VERSION.tar.bz2 | \
   tee >(sha256sum > binutils-$VERSION.tar.bz2.sha256)           | tar xjf -


### PR DESCRIPTION
Helps with an i586-unknown-linux-gnu build issue:

/rustroot/lib/gcc/x86_64-unknown-linux-gnu/4.7.4/../../../../x86_64-unknown-linux-gnu/bin/as: unrecognized option `-mrelax-relocations=no'

I'm not sure how this is working upstream, but updating binutils lets my local builds of 1.12-stable on top of this container complete.
