### PR TITLE
Curl 7.51.0

### DIFF
--- a/slaves/dist/build_cmake.sh
+++ b/slaves/dist/build_cmake.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=3.6.2
-SHA256=189ae32a6ac398bb2f523ae77f70d463a6549926cde1544cd9cc7c6609f8b346
+VERSION=3.6.3
+SHA256=7d73ee4fae572eb2d7cd3feb48971aea903bb30a20ea5ae8b4da826d8ccad5fe
 
 curl https://cmake.org/files/v${VERSION%\.*}/cmake-$VERSION.tar.gz | \
   tee >(sha256sum > cmake-$VERSION.tar.gz.sha256)                  | tar xzf -

--- a/slaves/dist/build_curl.sh
+++ b/slaves/dist/build_curl.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=7.50.3
-SHA256=7b7347d976661d02c84a1f4d6daf40dee377efdc45b9e2c77dedb8acf140d8ec
+VERSION=7.51.0
+SHA256=7f8240048907e5030f67be0a6129bc4b333783b9cca1391026d700835a788dde
 
 curl http://cool.haxx.se/download/curl-$VERSION.tar.bz2 | \
   tee >(sha256sum > curl-$VERSION.tar.bz2.sha256)       | tar xjf -


### PR DESCRIPTION
This is an important security update for curl. The cmake bump is just along for the ride.