### PR TITLE
Add ppc64le-linux platforms (nogate)

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -163,6 +163,10 @@ auto_platforms = [
     #"freebsd10_64-1",
     #"dragonflybsd-64-opt",
     #"openbsd-64-opt"
+    "ppc64le-linux-opt",
+    "ppc64le-linux-nopt-t",
+    "ppc64le-linux-rustbuild",
+    "ppc64le-linux-cargotest",
 ]
 
 try_platforms = ["linux", "win-gnu-32", "win-gnu-64", "mac"]
@@ -188,6 +192,7 @@ cargo_platforms = ["linux-32", "linux-64", "mac-32", "mac-64",
                    "win-gnu-32", "win-gnu-64",
                    "win-msvc-32", "win-msvc-64",
                    #"bitrig-64"
+                   "ppc64le-linux"
                    ]
 cargo_dist_platforms = [p for p in cargo_platforms if "linux" in p or "mac" in p or "win" in p]
 
@@ -212,6 +217,10 @@ nogate_builders = [
     "auto-dragonflybsd-64-opt",
     "auto-openbsd-64-opt",
     "auto-linux-rustbuild-cross-opt",
+    "auto-ppc64le-linux-opt",
+    "auto-ppc64le-linux-nopt-t",
+    "auto-ppc64le-linux-rustbuild",
+    "auto-ppc64le-linux-cargotest",
 ]
 dist_nogate_platforms = [
     #"mac-ios",
@@ -305,6 +314,8 @@ def all_platform_hosts(platform):
         return ["i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
     elif "arm-android" in platform:
         return ["x86_64-unknown-linux-gnu"]
+    elif "ppc64le" in platform:
+        return ["powerpc64le-unknown-linux-gnu"]
     elif "linux" in platform:
         return ["i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
     elif "freebsd10_32" in platform:
@@ -340,6 +351,9 @@ def auto_platform_triple(p):
             return "i686-apple-darwin"
         else:
             return "x86_64-apple-darwin"
+
+    if "ppc64le" in p:
+        return "powerpc64le-unknown-linux-gnu"
 
     if "linux" in p:
         if "-32" in p:


### PR DESCRIPTION
Hello!

Rust and cargo are in a state where PowerPC64LE can bootstrap from recent respective betas and nightlies (I'm yet to test BE). I'm keen to get some CI ducks in a row so that when `src/stage0.txt` is updated we can contribute results to the build matrix.

I think I've deciphered the bits I need from `master/master.cfg` such that only the platforms of interest are run on our ppc64le buildslaves, which I intend to name ppc64*-linux.

Andrew