### PR TITLE
Add a Fuchsia build slave

### DIFF
--- a/slaves/fuchsia/Dockerfile
+++ b/slaves/fuchsia/Dockerfile
@@ -1,0 +1,76 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --force-yes --no-install-recommends \
+	build-essential \
+	ca-certificates \
+	curl \
+	git \
+	golang \
+	unzip
+
+RUN curl -s https://raw.githubusercontent.com/fuchsia-mirror/jiri/master/scripts/bootstrap_jiri | bash -s fuchsia
+WORKDIR /fuchsia
+ENV PATH="/fuchsia/.jiri_root/bin:${PATH}"
+
+RUN jiri import sysroot https://fuchsia.googlesource.com/manifest
+
+# Patch the manifest to add scripts and llvm (for Fuchsia.cmake), and
+# also to bring in tools from magenta-rs. Hopefully the need for this
+# will go away soon.
+COPY fuchsia/manifest-patch /fuchsia/
+RUN patch .jiri_manifest < manifest-patch
+
+# Note: we have to fix the file ownership here or else it will cause
+# permissions problems when we change USER to rustbuild
+RUN jiri update && chmod -R u+rwX,go+rX /fuchsia/buildtools/toolchain
+
+RUN ./scripts/build-sysroot.sh -t x86_64
+RUN ./scripts/build-sysroot.sh -t aarch64
+
+# Build the clang wrapper
+WORKDIR /fuchsia/rust/magenta-rs/tools
+RUN g++ -O --std=c++11 clang_wrapper.cc -o clang_wrapper
+RUN ln -s clang_wrapper x86-64-unknown-fuchsia-ar && \
+    ln -s clang_wrapper x86-64-unknown-fuchsia-cc && \
+    ln -s clang_wrapper x86-64-unknown-fuchsia-clang++ && \
+    ln -s clang_wrapper aarch64-unknown-fuchsia-ar && \
+    ln -s clang_wrapper aarch64-unknown-fuchsia-cc && \
+    ln -s clang_wrapper aarch64-unknown-fuchsia-clang++
+
+ENV RUST_TOOLS=/fuchsia/rust/magenta-rs/tools
+
+ENV AR_x86_64_unknown_fuchsia=${RUST_TOOLS}/x86-64-unknown-fuchsia-ar \
+    CC_x86_64_unknown_fuchsia=${RUST_TOOLS}/x86-64-unknown-fuchsia-cc \
+    CXX_x86_64_unknown_fuchsia=${RUST_TOOLS}/x86-64-unknown-fuchsia-clang++ \
+    AR_aarch64_unknown_fuchsia=${RUST_TOOLS}/aarch64-unknown-fuchsia-ar \
+    CC_aarch64_unknown_fuchsia=${RUST_TOOLS}/aarch64-unknown-fuchsia-cc \
+    CXX_aarch64_unknown_fuchsia=${RUST_TOOLS}/aarch64-unknown-fuchsia-clang++
+
+# A script which can be used to build Rust from git HEAD
+COPY fuchsia/build-head-rust.sh /
+COPY fuchsia/config.toml /
+
+# The rest of this is adapted from the linux Dockerfile.
+
+RUN apt-get install -y \
+        curl make xz-utils git \
+        python-dev python-pip stunnel \
+        g++-multilib libssl-dev gdb \
+        valgrind \
+        cmake pkg-config
+
+# Install buildbot and prep it to run
+RUN pip install buildbot-slave
+RUN groupadd -r rustbuild && useradd -r -g rustbuild rustbuild
+RUN mkdir /buildslave && chown rustbuild:rustbuild /buildslave
+
+# When running this container, startup buildbot
+WORKDIR /buildslave
+RUN rm -rf /build
+
+# TODO: clean up more stuff not needed for Rust build
+
+USER rustbuild
+COPY start-docker-slave.sh start-docker-slave.sh
+ENTRYPOINT ["sh", "start-docker-slave.sh"]
+

--- a/slaves/fuchsia/README.md
+++ b/slaves/fuchsia/README.md
@@ -1,0 +1,26 @@
+# Buildslave for Fuchsia
+
+Go to the parent directory and run:
+
+```
+docker build -f fuchsia/Dockerfile .
+```
+
+This fetches relevant packages from the
+[Fuchsia](https://fuchsia.googlesource.com/fuchsia) repositories using
+[jiri](https://fuchsia.googlesource.com/jiri). The hooks for the
+magenta repo in turn fetch toolchain binaries from Google Cloud
+Storage.
+
+The Docker script builds a sysroot, and also builds the "clang
+wrapper". See the
+[magenta-rs](https://fuchsia.googlesource.com/magenta-rs/+/HEAD/GETTING_STARTED.md)
+documentation for more information on that.
+
+The resulting docker image can also be used to build a working Rust compiler:
+
+```
+docker run -it --entrypoint=/bin/bash ${IMAGE}
+/build-head-rust.sh
+```
+

--- a/slaves/fuchsia/build-head-rust.sh
+++ b/slaves/fuchsia/build-head-rust.sh
@@ -1,0 +1,15 @@
+# This shell script will build a stage1 Rust compiler from git HEAD
+
+set -e
+
+# Cargo tries to create ${HOME}/.cargo, make sure it can.
+export HOME=`pwd`
+
+git clone https://github.com/rust-lang/rust.git
+cd rust
+cp /config.toml .
+
+# apt-get install -y --force-yes --no-install-recommends file python cmake
+./configure --enable-rustbuild --target=x86_64-unknown-fuchsia
+./x.py build --stage 1
+

--- a/slaves/fuchsia/config.toml
+++ b/slaves/fuchsia/config.toml
@@ -1,0 +1,17 @@
+# Config file for fuchsia target for building Rust.
+# See `src/bootstrap/config.toml.example` for other settings.
+
+[rust]
+
+# Disable backtrace, as it requires additional lib support.
+backtrace = false
+
+[target.x86_64-unknown-fuchsia]
+
+cc = "/fuchsia/rust/magenta-rs/tools/x86-64-unknown-fuchsia-cc"
+
+[target.aarch64-unknown-fuchsia]
+
+# Path to the clang wrapper
+cc = "/fuchsia/rust/magenta-rs/tools/aarch64-unknown-fuchsia-cc"
+

--- a/slaves/fuchsia/manifest-patch
+++ b/slaves/fuchsia/manifest-patch
@@ -1,0 +1,24 @@
+--- .jiri_manifest	2016-12-13 18:46:54.000000000 -0800
++++ ../manifest-updated	2016-12-13 19:08:49.000000000 -0800
+@@ -2,4 +2,21 @@
+   <imports>
+     <import manifest="sysroot" name="manifest" remote="https://fuchsia.googlesource.com/manifest"/>
+   </imports>
++  <projects>
++    <project name="scripts"
++             path="scripts"
++             remote="https://fuchsia.googlesource.com/scripts"
++             gerrithost="https://fuchsia-review.googlesource.com"
++             githooks="manifest/git-hooks"/>
++    <project name="third_party/llvm"
++             path="third_party/llvm"
++             remote="https://fuchsia.googlesource.com/third_party/llvm"
++             gerrithost="https://fuchsia-review.googlesource.com"
++             githooks="manifest/git-hooks"/>
++    <project name="rust/magenta-rs"
++             path="rust/magenta-rs"
++             remote="https://fuchsia.googlesource.com/magenta-rs"
++             gerrithost="https://fuchsia-review.googlesource.com"
++             githooks="manifest/git-hooks"/>
++  </projects>
+ </manifest>


### PR DESCRIPTION
Adds a Docker script to build an image containing toolchain and sysroot for Fuchsia operating system.