### PR TITLE
Openssl 1.0.2k

### DIFF
--- a/slaves/dist/build_curl.sh
+++ b/slaves/dist/build_curl.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=7.51.0
-SHA256=7f8240048907e5030f67be0a6129bc4b333783b9cca1391026d700835a788dde
+VERSION=7.52.1
+SHA256=d16185a767cb2c1ba3d5b9096ec54e5ec198b213f45864a38b3bda4bbf87389b
 
 curl http://cool.haxx.se/download/curl-$VERSION.tar.bz2 | \
   tee >(sha256sum > curl-$VERSION.tar.bz2.sha256)       | tar xjf -

--- a/slaves/dist/build_gcc.sh
+++ b/slaves/dist/build_gcc.sh
@@ -6,7 +6,7 @@ VERSION=4.7.4
 SHA256=92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282
 
 yum install -y wget
-curl https://ftp.gnu.org/gnu/gcc/gcc-$VERSION/gcc-$VERSION.tar.bz2 | \
+curl http://ftp.gnu.org/gnu/gcc/gcc-$VERSION/gcc-$VERSION.tar.bz2 | \
   tee >(sha256sum > gcc-$VERSION.tar.bz2.sha256) | tar xjf -
 test $SHA256 = $(cut -d ' ' -f 1 gcc-$VERSION.tar.bz2.sha256) || exit 1
 

--- a/slaves/dist/build_git.sh
+++ b/slaves/dist/build_git.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=2.10.0
-SHA256=207cfce8cc0a36497abb66236817ef449a45f6ff9141f586bbe2aafd7bc3d90b
+VERSION=2.11.0
+SHA256=d3be9961c799562565f158ce5b836e2b90f38502d3992a115dfb653d7825fd7e
 
 yum install -y gettext autoconf
 curl https://www.kernel.org/pub/software/scm/git/git-$VERSION.tar.gz | \

--- a/slaves/dist/build_openssl.sh
+++ b/slaves/dist/build_openssl.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-VERSION=1.0.2j
-SHA256=e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431
+VERSION=1.0.2k
+SHA256=6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0
 
 yum install -y setarch
 curl ftp://ftp.openssl.org/source/openssl-$VERSION.tar.gz | \


### PR DESCRIPTION
Bump openssl, curl, and git to the latest releases.

Openssl has a fix for a medium vulnerability in Diffie-Hellman verification. Otherwise there's nothing critical for security here, it's just good to be up to date.

Be sure to build with `--no-cache` to pick up the Centos 5 update for [CVE-2016-9147](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9147).