### PR TITLE
Fixed the targets of analysis manifest entries.

### DIFF
--- a/master/build-rust-manifest.py
+++ b/master/build-rust-manifest.py
@@ -412,10 +412,11 @@ def build_manifest(rustc_date, rustc_version, rustc_short_version,
         }]
 
         if channel == "nightly":
-            extensions += [{
-            "pkg": "rust-analysis",
-            "target": target,
-        }]
+            for target in target_list:
+                extensions += [{
+                    "pkg": "rust-analysis",
+                    "target": target,
+                }]
 
         # The binaries of the 'rust' package are on the local disk.
         # url_and_hash_of_rust_package will try to locate them


### PR DESCRIPTION
Before this change, all entries would use the last visited target from the
previous loop, thus would not match their parent target section.

---

Ref https://github.com/rust-lang/rust-buildbot/pull/150#issuecomment-277362183