### PR TITLE
Update android ndk to r13b

### DIFF
--- a/slaves/android/Dockerfile
+++ b/slaves/android/Dockerfile
@@ -12,24 +12,25 @@ RUN pip install buildbot-slave
 RUN groupadd -r rustbuild && useradd -r -g rustbuild rustbuild
 RUN mkdir /buildslave && chown rustbuild:rustbuild /buildslave
 
-# Setup PATH to allow running android tools.
-ENV PATH=$PATH:/android/ndk-arm/bin:/android/ndk-aarch64/bin:/android/ndk-x86:/android/sdk/tools:/android/sdk/platform-tools
-
-# Not sure how to install 64-bit binaries in the sdk?
-ENV ANDROID_EMULATOR_FORCE_32BIT=true
-
 RUN mkdir /android && chown rustbuild:rustbuild /android
 RUN mkdir /home/rustbuild && chown rustbuild:rustbuild /home/rustbuild
 
 WORKDIR /android
 USER rustbuild
 
-COPY android/install-ndk.sh android/install-sdk.sh android/accept-licenses.sh \
-    /android/
+COPY android/*.sh /android/
+
+# Setup PATH to allow running android tools.
+ENV PATH=$PATH:/android/ndk-arm/bin:/android/ndk-aarch64/bin:/android/ndk-x86/bin:/android/sdk/tools:/android/sdk/platform-tools
 
 RUN sh install-ndk.sh
 RUN sh install-sdk.sh
 RUN rm *.sh
+
+# Setup SHELL so android can detect a 64bits system, see
+# http://stackoverflow.com/a/41789144
+# https://issues.jenkins-ci.org/browse/JENKINS-26930?focusedCommentId=230791&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-230791
+ENV SHELL /bin/dash
 
 # When running this container, startup buildbot
 WORKDIR /buildslave

--- a/slaves/android/install-ndk.sh
+++ b/slaves/android/install-ndk.sh
@@ -2,48 +2,28 @@
 
 set -ex
 
-cpgdb() {
-  cp android-ndk-r11c/prebuilt/linux-x86_64/bin/gdb /android/$1/bin/$2-gdb
-  cp android-ndk-r11c/prebuilt/linux-x86_64/bin/gdb-orig /android/$1/bin/gdb-orig
-  cp -r android-ndk-r11c/prebuilt/linux-x86_64/share /android/$1/share
-}
-
 # Prep the Android NDK
 #
 # See https://github.com/servo/servo/wiki/Building-for-Android
-curl -O http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip
-unzip -q android-ndk-r11c-linux-x86_64.zip
-bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
-        --platform=android-9 \
-        --toolchain=arm-linux-androideabi-4.9 \
-        --install-dir=/android/ndk-arm-9 \
-        --ndk-dir=/android/android-ndk-r11c \
-        --arch=arm
-cpgdb ndk-arm-9 arm-linux-androideabi
-bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
-        --platform=android-21 \
-        --toolchain=arm-linux-androideabi-4.9 \
-        --install-dir=/android/ndk-arm \
-        --ndk-dir=/android/android-ndk-r11c \
-        --arch=arm
-cpgdb ndk-arm arm-linux-androideabi
-bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
-        --platform=android-21 \
-        --toolchain=aarch64-linux-android-4.9 \
-        --install-dir=/android/ndk-aarch64 \
-        --ndk-dir=/android/android-ndk-r11c \
-        --arch=arm64
-bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
-        --platform=android-9 \
-        --toolchain=x86-4.9 \
-        --install-dir=/android/ndk-x86-9 \
-        --ndk-dir=/android/android-ndk-r11c \
-        --arch=x86
-bash android-ndk-r11c/build/tools/make-standalone-toolchain.sh \
-        --platform=android-21 \
-        --toolchain=x86_64-4.9 \
-        --install-dir=/android/ndk-x86_64 \
-        --ndk-dir=/android/android-ndk-r11c \
-        --arch=x86_64
+curl -O https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
+unzip -q android-ndk-r13b-linux-x86_64.zip
 
-rm -rf ./android-ndk-r11c-linux-x86_64.zip ./android-ndk-r11c
+# This tells the minimum android API version that we are targeting
+API=21
+
+android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+        --install-dir /android/ndk-arm \
+        --arch arm \
+        --api $API
+
+android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+        --install-dir /android/ndk-aarch64 \
+        --arch arm64 \
+        --api $API
+
+android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+        --install-dir /android/ndk-x86 \
+        --arch x86 \
+        --api $API
+
+rm -rf ./android-ndk-r13b-linux-x86_64.zip ./android-ndk-r13b

--- a/slaves/android/install-sdk.sh
+++ b/slaves/android/install-sdk.sh
@@ -13,29 +13,29 @@ mkdir sdk
 curl http://dl.google.com/android/android-sdk_r24.4-linux.tgz | \
     tar xzf - -C sdk --strip-components=1
 
-filter="platform-tools,android-18,android-21"
-filter="$filter,sys-img-x86-android-18"
-filter="$filter,sys-img-x86_64-android-18"
-filter="$filter,sys-img-armeabi-v7a-android-18"
-filter="$filter,sys-img-x86-android-21"
-filter="$filter,sys-img-x86_64-android-21"
-filter="$filter,sys-img-armeabi-v7a-android-21"
+# API 24 is the minimum to run arm64 emulator
+# Note that this is the API level of the emulator, not the api of the NDK
+# We can use an API for NDK that is less than or equal to this
+API=24
+
+filter="platform-tools,android-$API"
+filter="$filter,sys-img-armeabi-v7a-android-$API"
+filter="$filter,sys-img-arm64-v8a-android-$API"
+filter="$filter,sys-img-x86-android-$API"
 
 ./accept-licenses.sh "android - update sdk -a --no-ui --filter $filter"
 
 echo "no" | android create avd \
-                --name arm-18 \
-                --target android-18 \
+                --name arm-$API \
+                --target android-$API \
                 --abi armeabi-v7a
+
 echo "no" | android create avd \
-                --name arm-21 \
-                --target android-21 \
-                --abi armeabi-v7a
+                --name aarch64-$API \
+                --target android-$API \
+                --abi arm64-v8a
+
 echo "no" | android create avd \
-                --name x86-21 \
-                --target android-21 \
+                --name x86-$API \
+                --target android-$API \
                 --abi x86
-echo "no" | android create avd \
-                --name x86_64-21 \
-                --target android-21 \
-                --abi x86_64


### PR DESCRIPTION
This allows rustup and cargo be compiled for android on aarch64 and x86.

The old ndk has a compiler that segfaults em compiling openssl. The compiler with r13b ndk works fine.